### PR TITLE
点検履歴のバックエンド側の実装

### DIFF
--- a/sql/history.sql
+++ b/sql/history.sql
@@ -1,0 +1,25 @@
+CREATE TABLE histories (
+  check_history_id int unsigned AUTO_INCREMENT,
+  equipment_id int NOT NULL,
+  implementation_date DATE NOT NULL,
+  check_type VARCHAR(10) NOT NULL,
+  result VARCHAR(50) NOT NULL,
+  PRIMARY KEY(check_history_id)
+);
+
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (1, 1, "2022-09-30", "簡易点検", "良");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (2, 1, "2021-09-30", "本格点検", "良");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (3, 2, "2022-10-30", "簡易点検", "良");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (4, 2, "2020-10-30", "本格点検", "良");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (5, 3, "2021-11-30", "簡易点検", "良");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (6, 3, "2020-11-30", "簡易点検", "補修塗装を実施");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (7, 3, "2022-11-30", "本格点検", "ケーシングの腐食が進んでいたため交換を実施");
+INSERT INTO histories (check_history_id, equipment_id, implementation_date, check_type, result)
+VALUES (8, 3, "2019-11-30", "本格点検", "良");

--- a/src/main/java/com/example/equipment/controller/HistoryController.java
+++ b/src/main/java/com/example/equipment/controller/HistoryController.java
@@ -33,13 +33,13 @@ public class HistoryController {
     this.historyService = historyService;
   }
 
-  // 指定した設備の点検履歴を取得する
+  // 指定した設備IDの点検履歴を取得する
   @GetMapping("/equipments/{equipmentId}/histories")
   public List<History> getHistoryByEquipmentId(@PathVariable("equipmentId") int equipmentId) {
     return historyService.findHistoryByEquipmentId(equipmentId);
   }
 
-  // 指定した設備の点検履歴を登録する
+  // 指定した設備IDの点検履歴をHistoryForm型でリクエストされた内容で登録する
   @PostMapping("/equipments/{equipmentId}/histories")
   public ResponseEntity<Map<String, String>> createHistory(
       @PathVariable("equipmentId") int equipmentId,
@@ -51,6 +51,7 @@ public class HistoryController {
     return ResponseEntity.created(url).body(Map.of("message", "点検履歴が正常に登録されました"));
   }
 
+  // 指定したIDの点検履歴をHistoryForm型でリクエストされた内容で更新する
   @PatchMapping("/histories/{checkHistoryId}")
   public ResponseEntity<Map<String, String>> updateHistory(
       @PathVariable("checkHistoryId") int checkHistoryId,
@@ -60,6 +61,7 @@ public class HistoryController {
     return ResponseEntity.ok(Map.of("message", "点検履歴が正常に更新されました"));
   }
 
+  // 指定したIDの点検履歴を削除する
   @DeleteMapping("/histories/{checkHistoryId}")
   public ResponseEntity<Map<String, String>> deleteHistoryByCheckHistoryId(
       @PathVariable("checkHistoryId") int checkHistoryId) {
@@ -67,6 +69,7 @@ public class HistoryController {
     return ResponseEntity.ok(Map.of("message", "点検履歴が正常に削除されました"));
   }
 
+  // 指定した設備IDに紐づく点検履歴を削除する
   @DeleteMapping("/equipments/{equipmentId}/histories")
   public ResponseEntity<Map<String, String>> deleteHistoryByEquipmentId(
       @PathVariable("equipmentId") int equipmentId) {
@@ -74,6 +77,7 @@ public class HistoryController {
     return ResponseEntity.ok(Map.of("message", "点検履歴が正常に削除されました"));
   }
 
+  // リソースが存在しない時のエラーハンドリング
   @ExceptionHandler(value = ResourceNotFoundException.class)
   public ResponseEntity<Map<String, String>> handleNoResourceFound(
       ResourceNotFoundException e, HttpServletRequest request) {
@@ -86,6 +90,7 @@ public class HistoryController {
     return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
   }
 
+  // バリデーションチェックによるエラーハンドリング
   @ExceptionHandler(value = MethodArgumentNotValidException.class)
   public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException e, HttpServletRequest request) {

--- a/src/main/java/com/example/equipment/controller/HistoryController.java
+++ b/src/main/java/com/example/equipment/controller/HistoryController.java
@@ -1,0 +1,101 @@
+package com.example.equipment.controller;
+
+import com.example.equipment.entity.History;
+import com.example.equipment.exception.ResourceNotFoundException;
+import com.example.equipment.form.HistoryForm;
+import com.example.equipment.service.HistoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@CrossOrigin(origins = "http://localhost:3000")
+public class HistoryController {
+  private final HistoryService historyService;
+
+  public HistoryController(HistoryService historyService) {
+    this.historyService = historyService;
+  }
+
+  // 指定した設備の点検履歴を取得する
+  @GetMapping("/equipments/{equipmentId}/histories")
+  public List<History> getHistoryByEquipmentId(@PathVariable("equipmentId") int equipmentId) {
+    return historyService.findHistoryByEquipmentId(equipmentId);
+  }
+
+  // 指定した設備の点検履歴を登録する
+  @PostMapping("/equipments/{equipmentId}/histories")
+  public ResponseEntity<Map<String, String>> createHistory(
+      @PathVariable("equipmentId") int equipmentId,
+      @RequestBody @Validated HistoryForm form, UriComponentsBuilder uriBuilder) {
+    History history = historyService.createHistory(equipmentId, form);
+    URI url = uriBuilder
+        .path("/equipments/" + equipmentId + "/histories/" + history.getCheckHistoryId())
+        .build().toUri();
+    return ResponseEntity.created(url).body(Map.of("message", "点検履歴が正常に登録されました"));
+  }
+
+  @PatchMapping("/histories/{checkHistoryId}")
+  public ResponseEntity<Map<String, String>> updateHistory(
+      @PathVariable("checkHistoryId") int checkHistoryId,
+      @RequestBody @Validated HistoryForm form) {
+    historyService.updateHistory(
+        checkHistoryId, form.getImplementationDate(), form.getCheckType(), form.getResult());
+    return ResponseEntity.ok(Map.of("message", "点検履歴が正常に更新されました"));
+  }
+
+  @DeleteMapping("/histories/{checkHistoryId}")
+  public ResponseEntity<Map<String, String>> deleteHistoryByCheckHistoryId(
+      @PathVariable("checkHistoryId") int checkHistoryId) {
+    historyService.deleteHistoryByCheckHistoryId(checkHistoryId);
+    return ResponseEntity.ok(Map.of("message", "点検履歴が正常に削除されました"));
+  }
+
+  @DeleteMapping("/equipments/{equipmentId}/histories")
+  public ResponseEntity<Map<String, String>> deleteHistoryByEquipmentId(
+      @PathVariable("equipmentId") int equipmentId) {
+    historyService.deleteHistoryByEquipmentId(equipmentId);
+    return ResponseEntity.ok(Map.of("message", "点検履歴が正常に削除されました"));
+  }
+
+  @ExceptionHandler(value = ResourceNotFoundException.class)
+  public ResponseEntity<Map<String, String>> handleNoResourceFound(
+      ResourceNotFoundException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+        "message", e.getMessage(),
+        "path", request.getRequestURI());
+    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(value = MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+        "message", "implementationDate,checkType,"
+            + "resultは必須項目です。checkTypeは10文字以内、resultは50文字以内で入力してください",
+        "path", request.getRequestURI());
+    return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/example/equipment/entity/History.java
+++ b/src/main/java/com/example/equipment/entity/History.java
@@ -1,0 +1,25 @@
+package com.example.equipment.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+
+public class History {
+
+  private int checkHistoryId;
+  private int equipmentId;
+  private String implementationDate;
+  private String checkType;
+  private String result;
+
+  public History(int equipmentId, String implementationDate, String checkType, String result) {
+    this.equipmentId = equipmentId;
+    this.implementationDate = implementationDate;
+    this.checkType = checkType;
+    this.result = result;
+  }
+}

--- a/src/main/java/com/example/equipment/entity/History.java
+++ b/src/main/java/com/example/equipment/entity/History.java
@@ -3,6 +3,7 @@ package com.example.equipment.entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -21,5 +22,26 @@ public class History {
     this.implementationDate = implementationDate;
     this.checkType = checkType;
     this.result = result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    History history = (History) o;
+    return checkHistoryId == history.checkHistoryId
+        && equipmentId == history.equipmentId
+        && Objects.equals(implementationDate, history.implementationDate)
+        && Objects.equals(checkType, history.checkType)
+        && Objects.equals(result, history.result);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(checkHistoryId, equipmentId, implementationDate, checkType, result);
   }
 }

--- a/src/main/java/com/example/equipment/form/HistoryForm.java
+++ b/src/main/java/com/example/equipment/form/HistoryForm.java
@@ -1,0 +1,22 @@
+package com.example.equipment.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HistoryForm {
+
+  @NotBlank(message = "必須項目です")
+  private String implementationDate;
+
+  @Size(max = 10, message = "10文字以内で入力してください")
+  @NotBlank(message = "必須項目です")
+  private String checkType;
+
+  @Size(max = 50, message = "10文字以内で入力してください")
+  @NotBlank(message = "必須項目です")
+  private String result;
+}

--- a/src/main/java/com/example/equipment/form/HistoryForm.java
+++ b/src/main/java/com/example/equipment/form/HistoryForm.java
@@ -16,7 +16,7 @@ public class HistoryForm {
   @NotBlank(message = "必須項目です")
   private String checkType;
 
-  @Size(max = 50, message = "10文字以内で入力してください")
+  @Size(max = 50, message = "50文字以内で入力してください")
   @NotBlank(message = "必須項目です")
   private String result;
 }

--- a/src/main/java/com/example/equipment/mapper/HistoryMapper.java
+++ b/src/main/java/com/example/equipment/mapper/HistoryMapper.java
@@ -7,7 +7,6 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +24,7 @@ public interface HistoryMapper {
   @Options(useGeneratedKeys = true, keyProperty = "checkHistoryId")
   void insertHistory(History history);
 
-  @Update("UPDATE histories SET implementation_date = #{implementationDate} check_type = "
+  @Update("UPDATE histories SET implementation_date = #{implementationDate}, check_type = "
       + "#{checkType}, result = #{result} WHERE check_history_id = #{checkHistoryId}")
   void updateHistory(int checkHistoryId, String implementationDate, String checkType,
                      String result);

--- a/src/main/java/com/example/equipment/mapper/HistoryMapper.java
+++ b/src/main/java/com/example/equipment/mapper/HistoryMapper.java
@@ -1,0 +1,38 @@
+package com.example.equipment.mapper;
+
+import com.example.equipment.entity.History;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface HistoryMapper {
+
+  @Select("SELECT * FROM histories WHERE equipment_id = #{equipmentId}")
+  List<History> findHistoryByEquipmentId(int equipmentId);
+
+  @Select("SELECT * FROM histories WHERE check_history_id = #{checkHistoryId}")
+  Optional<History> findHistoryByCheckHistoryId(int checkHistoryId);
+
+  @Insert("INSERT INTO histories (equipment_id, implementation_date, check_type, result)"
+      + " VALUES (#{equipmentId}, #{implementationDate}, #{checkType}, #{result})")
+  @Options(useGeneratedKeys = true, keyProperty = "checkHistoryId")
+  void insertHistory(History history);
+
+  @Update("UPDATE histories SET implementation_date = #{implementationDate} check_type = "
+      + "#{checkType}, result = #{result} WHERE check_history_id = #{checkHistoryId}")
+  void updateHistory(int checkHistoryId, String implementationDate, String checkType,
+                     String result);
+
+  @Delete("DELETE FROM histories WHERE check_history_id = #{checkHistoryId}")
+  void deleteHistoryByCheckHistoryId(int checkPlanId);
+
+  @Delete("DELETE FROM histories WHERE equipment_id = #{equipmentId}")
+  void deleteHistoryByEquipmentId(int equipmentId);
+}

--- a/src/main/java/com/example/equipment/service/HistoryService.java
+++ b/src/main/java/com/example/equipment/service/HistoryService.java
@@ -1,0 +1,20 @@
+package com.example.equipment.service;
+
+import com.example.equipment.entity.History;
+import com.example.equipment.form.HistoryForm;
+
+import java.util.List;
+
+public interface HistoryService {
+
+  List<History> findHistoryByEquipmentId(int equipmentId);
+
+  History createHistory(int equipmentId, HistoryForm form);
+
+  void updateHistory(int checkHistoryId, String implementationDate, String checkType,
+                     String result);
+
+  void deleteHistoryByCheckHistoryId(int checkHistoryId);
+
+  void deleteHistoryByEquipmentId(int equipmentId);
+}

--- a/src/main/java/com/example/equipment/service/HistoryService.java
+++ b/src/main/java/com/example/equipment/service/HistoryService.java
@@ -2,7 +2,6 @@ package com.example.equipment.service;
 
 import com.example.equipment.entity.History;
 import com.example.equipment.form.HistoryForm;
-
 import java.util.List;
 
 public interface HistoryService {

--- a/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
@@ -14,12 +14,12 @@ public class HistoryServiceImpl implements HistoryService {
   private final HistoryMapper historyMapper;
   private final EquipmentMapper equipmentMapper;
 
-  public HistoryServiceImpl(HistoryMapper hisotryMapper, EquipmentMapper equipmentMapper) {
-    this.historyMapper = hisotryMapper;
+  public HistoryServiceImpl(HistoryMapper historyMapper, EquipmentMapper equipmentMapper) {
+    this.historyMapper = historyMapper;
     this.equipmentMapper = equipmentMapper;
   }
 
-  // 指定した設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDの点検履歴を取得するMapperを呼び出す。設備IDが存在しない場合は例外をスローする
   @Override
    public List<History> findHistoryByEquipmentId(int equipmentId) {
     equipmentMapper.findEquipmentById(equipmentId)
@@ -28,7 +28,8 @@ public class HistoryServiceImpl implements HistoryService {
     return historyMapper.findHistoryByEquipmentId(equipmentId);
   }
 
-  // 指定した設備IDが存在しない場合は例外をスローする
+  // formからgetしたリクエスト内容で、指定した設備IDの点検履歴を登録するMapperを呼び出す。
+  // 設備IDが存在しない場合は例外をスローする
   @Override
   public History createHistory(int equipmentId, HistoryForm form) {
     equipmentMapper.findEquipmentById(equipmentId)
@@ -40,6 +41,8 @@ public class HistoryServiceImpl implements HistoryService {
     return history;
   }
 
+  // formでリクエストされた内容で、指定したIDの点検履歴を更新するMapperを呼び出す。
+  // 指定した点検履歴IDが存在しない場合は例外をスローする
   @Override
   public void updateHistory(
       int checkHistoryId, String implementationDate, String checkType, String result) {
@@ -48,6 +51,7 @@ public class HistoryServiceImpl implements HistoryService {
     historyMapper.updateHistory(checkHistoryId, implementationDate, checkType, result);
   }
 
+  // 指定したIDの点検履歴を削除するMapperを呼び出す。点検履歴IDが存在しない場合は例外をスローする
   @Override
   public void deleteHistoryByCheckHistoryId(int checkHistoryId) {
     historyMapper.findHistoryByCheckHistoryId(checkHistoryId)
@@ -55,6 +59,7 @@ public class HistoryServiceImpl implements HistoryService {
     historyMapper.deleteHistoryByCheckHistoryId(checkHistoryId);
   }
 
+  // 指定した設備IDに紐づく点検履歴を削除するMapperを呼びだす。設備IDが存在しない場合は例外をスローする
   @Override
   public void deleteHistoryByEquipmentId(int equipmentId) {
     equipmentMapper.findEquipmentById(equipmentId)

--- a/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
@@ -1,0 +1,64 @@
+package com.example.equipment.service;
+
+import com.example.equipment.entity.History;
+import com.example.equipment.exception.ResourceNotFoundException;
+import com.example.equipment.form.HistoryForm;
+import com.example.equipment.mapper.EquipmentMapper;
+import com.example.equipment.mapper.HistoryMapper;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class HistoryServiceImpl implements HistoryService {
+
+  private final HistoryMapper historyMapper;
+  private final EquipmentMapper equipmentMapper;
+
+  public HistoryServiceImpl(HistoryMapper hisotryMapper, EquipmentMapper equipmentMapper) {
+    this.historyMapper = hisotryMapper;
+    this.equipmentMapper = equipmentMapper;
+  }
+
+  // 指定した設備IDが存在しない場合は例外をスローする
+  @Override
+   public List<History> findHistoryByEquipmentId(int equipmentId) {
+    equipmentMapper.findEquipmentById(equipmentId)
+        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+
+    return historyMapper.findHistoryByEquipmentId(equipmentId);
+  }
+
+  // 指定した設備IDが存在しない場合は例外をスローする
+  @Override
+  public History createHistory(int equipmentId, HistoryForm form) {
+    equipmentMapper.findEquipmentById(equipmentId)
+        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+
+    History history = new History(equipmentId, form.getImplementationDate(), form.getCheckType(),
+        form.getResult());
+    historyMapper.insertHistory(history);
+    return history;
+  }
+
+  @Override
+  public void updateHistory(
+      int checkHistoryId, String implementationDate, String checkType, String result) {
+    historyMapper.findHistoryByCheckHistoryId(checkHistoryId)
+        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+    historyMapper.updateHistory(checkHistoryId, implementationDate, checkType, result);
+  }
+
+  @Override
+  public void deleteHistoryByCheckHistoryId(int checkHistoryId) {
+    historyMapper.findHistoryByCheckHistoryId(checkHistoryId)
+        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+    historyMapper.deleteHistoryByCheckHistoryId(checkHistoryId);
+  }
+
+  @Override
+  public void deleteHistoryByEquipmentId(int equipmentId) {
+    equipmentMapper.findEquipmentById(equipmentId)
+        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+    historyMapper.deleteHistoryByEquipmentId(equipmentId);
+  }
+}

--- a/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
@@ -1,0 +1,420 @@
+package com.example.equipment.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class HistoryIntegrationTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  // GETメソッドで存在する設備IDを指定した時に、指定した設備IDの点検履歴が取得できステータスコード200が返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 指定した設備IDの点検履歴が取得できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.get("/equipments/1/histories"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+               [
+                 {
+                    "checkHistoryId": 1,
+                    "equipmentId": 1,
+                    "implementationDate": "2022-09-30",
+                    "checkType": "簡易点検",
+                    "result": "良"
+                 },
+                 {
+                   "checkHistoryId": 2,
+                   "equipmentId": 1,
+                   "implementationDate": "2021-09-30",
+                   "checkType": "本格点検",
+                   "result": "良"
+                 }
+               ]
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // GETメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 指定したIDの設備が存在しない時に例外がスローされること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.get("/equipments/4/histories"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "404",
+          "error": "Not Found",
+          "message": "Not Found",
+          "path": "/equipments/4/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // GETメソッドで点検履歴が存在しない時に、空のListが返されステータスコード200が返されること
+  @Test
+  @DataSet(value = "datasets/history/empty.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 点検計画が存在しない時に空のListが取得できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.get("/equipments/1/histories"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        []
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // POSTメソッドで正しくリクエスト（implementationDate,checkType,resultが全て入力されており、
+  // checkTypeは10文字以内で入力、resultは50文字以内で入力）した時に、
+  // 指定した設備の点検履歴が登録できステータスコード201とメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @ExpectedDataSet(value = "datasets/history/insert_history.yml", ignoreCols = "check_history_id")
+  @Transactional
+  void 指定した設備の点検履歴が登録できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": "2015-09-30",
+                  "checkType": "取替",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isCreated())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "message": "点検履歴が正常に登録されました"
+        }
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // POSTメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 登録の際に指定した設備IDが存在しない時に例外がスローされること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/4/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                    {
+                      "implementationDate": "2015-09-30",
+                      "checkType": "取替",
+                      "result": "良"
+                    }
+                    """))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "404",
+          "error": "Not Found",
+          "message": "Not Found",
+          "path": "/equipments/4/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // POSTメソッドでリクエストのimplementationDate,checkType,resultのいずれかがnullの時に、
+  // ステータスコード400とエラーメッセージが返されること（NotBlankのバリデーション確認、
+  // implementationDate,checkType,resultは同じString型のため、代表してimplementationDateで確認。以下同様）
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 登録時のリクエストでnullの項目がある時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": null,
+                  "checkType": "取替",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "400",
+          "error": "Bad Request",
+          "message": "implementationDate,checkType,resultは必須項目です。checkTypeは10文字以内、resultは50文字以内で入力してください",
+          "path": "/equipments/1/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // POSTメソッドでリクエストのimplementationDate,checkType,resultのいずれかが空文字の時に、
+  // ステータスコード400とエラーメッセージが返されること（NotBlankのバリデーション確認）
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 登録時のリクエストで空文字の項目がある時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": null,
+                  "checkType": "取替",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "400",
+          "error": "Bad Request",
+          "message": "implementationDate,checkType,resultは必須項目です。checkTypeは10文字以内、resultは50文字以内で入力してください",
+          "path": "/equipments/1/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // POSTメソッドでリクエストのcheckTypeが10文字を超えている時に、
+  // ステータスコード400とエラーメッセージが返されること（@Size(max = 10)のバリデーション確認、resultは割愛）
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 登録時のリクエストで10文字を超える項目がある時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": "2015-09-30",
+                  "checkType": "aaaaaaaaaaa",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "400",
+          "error": "Bad Request",
+          "message": "implementationDate,checkType,resultは必須項目です。checkTypeは10文字以内、resultは50文字以内で入力してください",
+          "path": "/equipments/1/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // PATCHメソッドで存在する点検履歴IDを指定し正しくリクエスト（implementationDate,checkType,resultが
+  // 全て入力されており、checkTypeは10文字以内で入力、resultは50文字以内で入力）した時に、
+  // 点検計画が更新できステータスコード200とメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/update_history.yml")
+  @Transactional
+  void 指定したIDの点検履歴が更新できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.patch("/histories/2")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": "2015-09-30",
+                  "checkType": "取替",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "message": "点検履歴が正常に更新されました"
+        }
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // PATCHメソッドで存在しない点検履歴IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
+  void 更新の際に指定した点検履歴IDが存在しない時に例外がスローされること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.patch("/histories/5")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "implementationDate": "2015-09-30",
+                  "checkType": "取替",
+                  "result": "良"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "404",
+          "error": "Not Found",
+          "message": "Not Found",
+          "path": "/histories/5"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // PATCHメソッドでリクエストのimplementationDate,checkType,resultのいずれかがnullの時に、
+  // ステータスコード400とエラーメッセージが返されること
+  // （NotBlankのバリデーション確認、POSTメソッドでも確認しているため空文字と文字数制限を超える場合は割愛）
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
+  void 更新リクエストでnullの項目がある時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.patch("/histories/2")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                    {
+                      "implementationDate": null,
+                      "checkType": "取替",
+                      "result": "良"
+                    }
+                    """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "400",
+          "error": "Bad Request",
+          "message": "implementationDate,checkType,resultは必須項目です。checkTypeは10文字以内、resultは50文字以内で入力してください",
+          "path": "/histories/2"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // DELETEメソッドで存在する点検履歴IDを指定した時に、点検履歴が削除できステータスコード200とメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/delete_history.yml")
+  @Transactional
+  void 指定したIDの点検履歴が削除できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.delete("/histories/4"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "message": "点検履歴が正常に削除されました"
+        }
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // DELETEメソッドで存在しない点検履歴IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
+  void 削除の際に指定した点検履歴IDが存在しない時に例外がスローされること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.delete("/histories/5"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "404",
+          "error": "Not Found",
+          "message": "Not Found",
+          "path": "/histories/5"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  // DELETEメソッドで存在する設備IDを指定した時に、点検履歴が削除できステータスコード200とメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/delete_by_equipment_id.yml")
+  @Transactional
+  void 指定した設備IDの点検履歴が削除できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.delete("/equipments/2/histories"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "message": "点検履歴が正常に削除されました"
+        }
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // DELETEメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 削除の際に指定した設備IDが存在しない時に例外がスローされること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.delete("/equipments/4/plans"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "404",
+          "error": "Not Found",
+          "message": "Not Found",
+          "path": "/equipments/4/plans"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+}

--- a/src/test/java/com/example/equipment/mapper/HistoryMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/HistoryMapperTest.java
@@ -1,0 +1,80 @@
+package com.example.equipment.mapper;
+
+import com.example.equipment.entity.History;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class HistoryMapperTest {
+
+  @Autowired
+  HistoryMapper historyMapper;
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
+  void 指定した設備IDの点検履歴が取得できること() {
+    assertThat(historyMapper.findHistoryByEquipmentId(1)).hasSize(2).contains(
+        new History(1, 1, "2022-09-30", "簡易点検", "良"),
+        new History(2, 1, "2021-09-30", "本格点検", "良")
+    );
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/empty.yml")
+  @Transactional
+  void 点検履歴が無い時に空のListが返されること() {
+    assertThat(historyMapper.findHistoryByEquipmentId(1)).isEmpty();
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
+  void 指定した点検履歴IDが存在しない時に空のOptionalが返されること() {
+    assertThat(historyMapper.findHistoryByCheckHistoryId(5)).isEmpty();
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/insert_history.yml", ignoreCols = "check_history_id")
+  @Transactional
+  void 点検履歴の登録ができ既存のIDより大きい数字の点検履歴IDが採番されること() {
+    History history =new History(1, "2015-09-30", "取替", "良");
+    historyMapper.insertHistory(history);
+    assertThat(history.getCheckHistoryId()).isGreaterThan(4);
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/update_history.yml")
+  @Transactional
+  void 指定したIDの点検履歴が更新できること() {
+    historyMapper.updateHistory(2, "2015-09-30", "取替", "良");
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/delete_history.yml")
+  @Transactional
+  void 指定したIDの点検履歴が削除できること() {
+    historyMapper.deleteHistoryByCheckHistoryId(4);
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @ExpectedDataSet(value = "datasets/history/delete_by_equipment_id.yml")
+  @Transactional
+  void 指定した設備IDに紐づく点検履歴が削除できること() {
+    historyMapper.deleteHistoryByEquipmentId(2);
+  }
+}

--- a/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
+++ b/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
@@ -1,0 +1,96 @@
+package com.example.equipment.service;
+
+import com.example.equipment.entity.History;
+import com.example.equipment.exception.ResourceNotFoundException;
+import com.example.equipment.form.HistoryForm;
+import com.example.equipment.mapper.EquipmentMapper;
+import com.example.equipment.mapper.HistoryMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryServiceImplTest {
+
+  @InjectMocks
+  HistoryServiceImpl historyServiceImpl;
+
+  @Mock
+  HistoryMapper historyMapper;
+
+  @Mock
+  EquipmentMapper equipmentMapper;
+
+  @Test
+  public void 点検履歴取得の際に存在しない設備IDを指定した時に例外がスローされること() {
+    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
+
+    assertThatThrownBy(() -> historyServiceImpl.findHistoryByEquipmentId(99))
+        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("Not Found");
+        });
+    verify(equipmentMapper, times(1)).findEquipmentById(99);
+    verify(historyMapper, never()).findHistoryByEquipmentId(99);
+  }
+
+  @Test
+  public void 点検履歴登録の際に存在しない設備IDを指定した時に例外がスローされること() {
+    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
+
+    HistoryForm form = new HistoryForm("2022-08-31", "取替", "良");
+    History history = new History(99, form.getImplementationDate(), form.getCheckType(), form.getResult());
+    assertThatThrownBy(() -> historyServiceImpl.createHistory(99, form))
+        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("Not Found");
+        });
+    verify(equipmentMapper, times(1)).findEquipmentById(99);
+    verify(historyMapper, never()).insertHistory(history);
+  }
+
+  @Test
+  public void 点検履歴更新の際に存在しない点検履歴IDを指定した時に例外がスローされること() {
+    doReturn(Optional.empty()).when(historyMapper).findHistoryByCheckHistoryId(99);
+
+    assertThatThrownBy(() -> historyServiceImpl.updateHistory(99, "2022-08-31", "取替", "良"))
+        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("Not Found");
+        });
+    verify(historyMapper, times(1)).findHistoryByCheckHistoryId(99);
+    verify(historyMapper, never()).updateHistory(99, "2022-08-31", "取替", "良");
+  }
+
+  @Test
+  public void 点検履歴削除の際に存在しない点検計画IDを指定した時に例外がスローされること() {
+    doReturn(Optional.empty()).when(historyMapper).findHistoryByCheckHistoryId(99);
+
+    assertThatThrownBy(() -> historyServiceImpl.deleteHistoryByCheckHistoryId(99))
+        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("Not Found");
+        });
+    verify(historyMapper, times(1)).findHistoryByCheckHistoryId(99);
+    verify(historyMapper, never()).deleteHistoryByCheckHistoryId(99);
+  }
+
+  @Test
+  public void 点検履歴削除の際に存在しない設備IDを指定した時に例外がスローされること() {
+    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
+
+    assertThatThrownBy(() -> historyServiceImpl.deleteHistoryByEquipmentId(99))
+        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("Not Found");
+        });
+    verify(equipmentMapper, times(1)).findEquipmentById(99);
+    verify(historyMapper, never()).deleteHistoryByEquipmentId(99);
+  }
+}

--- a/src/test/resources/datasets/history/delete_by_equipment_id.yml
+++ b/src/test/resources/datasets/history/delete_by_equipment_id.yml
@@ -1,0 +1,11 @@
+histories:
+  - check_history_id: 1
+    equipment_id: 1
+    implementation_date: "2022-09-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 2
+    equipment_id: 1
+    implementation_date: "2021-09-30"
+    check_type: "本格点検"
+    result: "良"

--- a/src/test/resources/datasets/history/delete_history.yml
+++ b/src/test/resources/datasets/history/delete_history.yml
@@ -1,0 +1,16 @@
+histories:
+  - check_history_id: 1
+    equipment_id: 1
+    implementation_date: "2022-09-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 2
+    equipment_id: 1
+    implementation_date: "2021-09-30"
+    check_type: "本格点検"
+    result: "良"
+  - check_history_id: 3
+    equipment_id: 2
+    implementation_date: "2022-10-30"
+    check_type: "簡易点検"
+    result: "良"

--- a/src/test/resources/datasets/history/empty.yml
+++ b/src/test/resources/datasets/history/empty.yml
@@ -1,0 +1,1 @@
+histories:

--- a/src/test/resources/datasets/history/histories.yml
+++ b/src/test/resources/datasets/history/histories.yml
@@ -1,0 +1,21 @@
+histories:
+  - check_history_id: 1
+    equipment_id: 1
+    implementation_date: "2022-09-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 2
+    equipment_id: 1
+    implementation_date: "2021-09-30"
+    check_type: "本格点検"
+    result: "良"
+  - check_history_id: 3
+    equipment_id: 2
+    implementation_date: "2022-10-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 4
+    equipment_id: 2
+    implementation_date: "2020-09-30"
+    check_type: "本格点検"
+    result: "良"

--- a/src/test/resources/datasets/history/insert_history.yml
+++ b/src/test/resources/datasets/history/insert_history.yml
@@ -1,0 +1,26 @@
+histories:
+  - check_history_id: 1
+    equipment_id: 1
+    implementation_date: "2022-09-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 2
+    equipment_id: 1
+    implementation_date: "2021-09-30"
+    check_type: "本格点検"
+    result: "良"
+  - check_history_id: 3
+    equipment_id: 2
+    implementation_date: "2022-10-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 4
+    equipment_id: 2
+    implementation_date: "2020-09-30"
+    check_type: "本格点検"
+    result: "良"
+  - check_history_id: 5
+    equipment_id: 1
+    implementation_date: "2015-09-30"
+    check_type: "取替"
+    result: "良"

--- a/src/test/resources/datasets/history/update_history.yml
+++ b/src/test/resources/datasets/history/update_history.yml
@@ -1,0 +1,21 @@
+histories:
+  - check_history_id: 1
+    equipment_id: 1
+    implementation_date: "2022-09-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 2
+    equipment_id: 1
+    implementation_date: "2015-09-30"
+    check_type: "取替"
+    result: "良"
+  - check_history_id: 3
+    equipment_id: 2
+    implementation_date: "2022-10-30"
+    check_type: "簡易点検"
+    result: "良"
+  - check_history_id: 4
+    equipment_id: 2
+    implementation_date: "2020-09-30"
+    check_type: "本格点検"
+    result: "良"


### PR DESCRIPTION
以下を実装
- 指定した設備IDの点検履歴検索
- 指定した設備IDの点検履歴登録処理
- 指定した点検履歴IDの点検履歴更新処理
- 指定した点検履歴IDの点検履歴削除処理
- 指定した設備IDに紐づく点検履歴削除処理
- 上記のテストコード
  - HistoryServiceImpl, HistoryMapperの単体テスト
  - History結合テスト