### PR TITLE
点検期限による設備検索機能を追加

### DIFF
--- a/frontend/src/components/FindEquipment.tsx
+++ b/frontend/src/components/FindEquipment.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, HStack, Heading, Input, Table, TableContainer, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/react";
+import { Box, Divider, HStack, Heading, Input, Table, TableContainer, Text, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/react";
 import axios from "axios";
 import { ChangeEvent, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -54,9 +54,9 @@ export const FindEquipment = () => {
       </HStack>
       <br />
       <br />
-      <Heading size='md'>検索条件入力</Heading>
+      <Heading size='lg'>検索条件入力</Heading>
       <Divider my={3} />
-      <HStack spacing={4}>
+      <HStack spacing={4} >
         <Box>
           <p>設備名称</p>
           <Input width={"400px"} placeholder="ポンプ" onChange={onChangeName} />
@@ -71,8 +71,9 @@ export const FindEquipment = () => {
           <Input width={"400px"} placeholder="Area1" onChange={onChangeLocation} />
         </Box>
         <Box>
-          <p>点検期限</p>
-          <Input width={"400px"} placeholder="2023-12-31" onChange={onChangeDeadline} />
+          <p>点検期限（点検期限が指定した日付以前の設備を検索）</p>
+          <Input width={"400px"} placeholder="2023-12-31（yyyy-mm-ddで入力してください）" 
+          onChange={onChangeDeadline} />
         </Box>
       </HStack>
       <br />

--- a/frontend/src/components/FindEquipment.tsx
+++ b/frontend/src/components/FindEquipment.tsx
@@ -9,6 +9,7 @@ export type Equipment = {
   name: string;
   number: string;
   location: string;
+  checkPlanId: number;
   checkType: string;
   deadline: string;
 };
@@ -94,7 +95,7 @@ export const FindEquipment = () => {
           </Thead>
           <Tbody>
             {equipments?.map((equipment) => (
-              <Tr key={equipment.equipmentId}>
+              <Tr key={equipment.checkPlanId}>
                 <Td color={"blue"}>
                   <Link to={`/update/${equipment.equipmentId}`} state={{ id: equipment.equipmentId }}>{equipment.name}</Link>
                 </Td>

--- a/frontend/src/components/FindEquipment.tsx
+++ b/frontend/src/components/FindEquipment.tsx
@@ -9,12 +9,15 @@ export type Equipment = {
   name: string;
   number: string;
   location: string;
+  checkType: string;
+  deadline: string;
 };
 
 export const FindEquipment = () => {
   const [name, setName] = useState("");
   const [number, setNumber] = useState("");
   const [location, setLocation] = useState("");
+  const [deadline, setDeadline] = useState("");
   const [equipments, setEquipments] = useState<Array<Equipment>>([]);
 
   const navigate = useNavigate();
@@ -26,11 +29,20 @@ export const FindEquipment = () => {
   const onChangeName = (e: ChangeEvent<HTMLInputElement>) => setName(e.target.value);
   const onChangeNumber = (e: ChangeEvent<HTMLInputElement>) => setNumber(e.target.value);
   const onChangeLocation = (e: ChangeEvent<HTMLInputElement>) => setLocation(e.target.value);
+  const onChangeDeadline = (e: ChangeEvent<HTMLInputElement>) => setDeadline(e.target.value);
 
   // Spring BootのAPIを叩いて、前段で入力した条件に合致する設備情報を取得する。
   const onClickFindEquipment = () => {
-    axios.get<Array<Equipment>>(`http://localhost:8080/equipments?name=${name}&number=${number}&location=${location}`)
+    axios.get<Array<Equipment>>(`http://localhost:8080/equipments?name=${name}&number=${number}&location=${location}&deadline=${deadline}`)
       .then((res) => setEquipments(res.data));
+  };
+
+  // １ヶ月後の日付をyyyy-mm-dd形式に変換する
+  const formatOneMonthAhead = (dt: Date) => {
+    var y = dt.getFullYear();
+    var m = ('00' + (dt.getMonth() + 2)).slice(-2);
+    var d = ('00' + dt.getDate()).slice(-2);
+    return (y + '-' + m + '-' + d);
   };
 
   return (
@@ -57,6 +69,10 @@ export const FindEquipment = () => {
           <p>設置場所</p>
           <Input width={"400px"} placeholder="Area1" onChange={onChangeLocation} />
         </Box>
+        <Box>
+          <p>点検期限</p>
+          <Input width={"400px"} placeholder="2023-12-31" onChange={onChangeDeadline} />
+        </Box>
       </HStack>
       <br />
       <BaseButton onClick={onClickFindEquipment}>検索</BaseButton>
@@ -65,13 +81,15 @@ export const FindEquipment = () => {
       <br />
       <Heading size='lg'>検索結果</Heading>
       <Divider my={3} />
-      <TableContainer width={1200}>
+      <TableContainer>
         <Table variant='simple'>
           <Thead>
             <Tr>
               <Th>設備名称</Th>
               <Th>設備番号</Th>
               <Th>設置場所</Th>
+              <Th>点検種別</Th>
+              <Th>点検期限</Th>
             </Tr>
           </Thead>
           <Tbody>
@@ -82,6 +100,10 @@ export const FindEquipment = () => {
                 </Td>
                 <Td >{equipment.number}</Td>
                 <Td>{equipment.location}</Td>
+                <Td>{equipment.checkType}</Td>
+                <Td style={{ color: formatOneMonthAhead(new Date()) >= equipment.deadline ? "red" : "black" }}>
+                  {equipment.deadline}
+                </Td>
               </Tr>
             ))}
           </Tbody>

--- a/src/main/java/com/example/equipment/controller/EquipmentController.java
+++ b/src/main/java/com/example/equipment/controller/EquipmentController.java
@@ -35,12 +35,13 @@ public class EquipmentController {
   }
 
   @GetMapping("/equipments")
-  public List<Equipment> getEquipments(
+  public List<FindEquipmentResponse> getEquipments(
       @RequestParam(value = "name", required = false) String name,
       @RequestParam(value = "number", required = false) String number,
-      @RequestParam(value = "location", required = false) String location
+      @RequestParam(value = "location", required = false) String location,
+      @RequestParam(value = "deadline", required = false) String deadline
   ) {
-    return equipmentService.findEquipment(name, number, location);
+    return equipmentService.findEquipment(name, number, location, deadline);
   }
 
   @GetMapping("/equipments/{equipmentId}")

--- a/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
+++ b/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
@@ -2,6 +2,7 @@ package com.example.equipment.controller;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
@@ -13,4 +14,26 @@ public class FindEquipmentResponse {
   private String location;
   private String checkType;
   private String deadline;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FindEquipmentResponse that = (FindEquipmentResponse) o;
+    return equipmentId == that.equipmentId
+        && Objects.equals(name, that.name)
+        && Objects.equals(number, that.number)
+        && Objects.equals(location, that.location)
+        && Objects.equals(checkType, that.checkType)
+        && Objects.equals(deadline, that.deadline);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(equipmentId, name, number, location, checkType, deadline);
+  }
 }

--- a/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
+++ b/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
@@ -12,6 +12,7 @@ public class FindEquipmentResponse {
   private String name;
   private String number;
   private String location;
+  private Integer checkPlanId;
   private String checkType;
   private String deadline;
 

--- a/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
+++ b/src/main/java/com/example/equipment/controller/FindEquipmentResponse.java
@@ -1,0 +1,16 @@
+package com.example.equipment.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindEquipmentResponse {
+
+  private int equipmentId;
+  private String name;
+  private String number;
+  private String location;
+  private String checkType;
+  private String deadline;
+}

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -15,14 +15,14 @@ import java.util.Optional;
 public interface EquipmentMapper {
 
   @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
-      + "FROM equipments JOIN plans ON equipments.equipment_id = plans.equipment_id "
+      + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
       + "AND location LIKE '%${location}%'")
   List<FindEquipmentResponse> findEquipment(
       String name, String number, String location);
 
   @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
-      + "FROM equipments JOIN plans ON equipments.equipment_id = plans.equipment_id "
+      + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
       + "AND location LIKE '%${location}%' AND deadline <= #{deadline}")
   List<FindEquipmentResponse> findEquipmentByDate(

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -17,14 +17,16 @@ public interface EquipmentMapper {
   @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
       + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
-      + "AND location LIKE '%${location}%'")
+      + "AND location LIKE '%${location}%'"
+      + "ORDER BY equipments.equipment_id, deadline ASC")
   List<FindEquipmentResponse> findEquipment(
       String name, String number, String location);
 
   @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
       + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
-      + "AND location LIKE '%${location}%' AND deadline <= #{deadline}")
+      + "AND location LIKE '%${location}%' AND deadline <= #{deadline}"
+      + "ORDER BY equipments.equipment_id, deadline ASC")
   List<FindEquipmentResponse> findEquipmentByDate(
       String name, String number, String location, String deadline);
 

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -1,5 +1,6 @@
 package com.example.equipment.mapper;
 
+import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
@@ -13,9 +14,19 @@ import java.util.Optional;
 @Mapper
 public interface EquipmentMapper {
 
-  @Select("SELECT * FROM equipments WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' AND"
-      + " location LIKE '%${location}%'")
-  List<Equipment> findEquipment(String name, String number, String location);
+  @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
+      + "FROM equipments JOIN plans ON equipments.equipment_id = plans.equipment_id "
+      + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
+      + "AND location LIKE '%${location}%'")
+  List<FindEquipmentResponse> findEquipment(
+      String name, String number, String location);
+
+  @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
+      + "FROM equipments JOIN plans ON equipments.equipment_id = plans.equipment_id "
+      + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
+      + "AND location LIKE '%${location}%' AND deadline <= #{deadline}")
+  List<FindEquipmentResponse> findEquipmentByDate(
+      String name, String number, String location, String deadline);
 
   @Select("SELECT * FROM equipments WHERE equipment_id = #{equipmentId}")
   Optional<Equipment> findEquipmentById(int equipmentId);

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 @Mapper
 public interface EquipmentMapper {
 
-  @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
+  @Select("SELECT equipments.equipment_id, name, number, location, "
+      + "check_plan_id, check_type, deadline "
       + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
       + "AND location LIKE '%${location}%'"
@@ -22,7 +23,8 @@ public interface EquipmentMapper {
   List<FindEquipmentResponse> findEquipment(
       String name, String number, String location);
 
-  @Select("SELECT equipments.equipment_id, name, number, location, check_type, deadline "
+  @Select("SELECT equipments.equipment_id, name, number, location, "
+      + "check_plan_id, check_type, deadline "
       + "FROM equipments LEFT JOIN plans ON equipments.equipment_id = plans.equipment_id "
       + "WHERE name LIKE '%${name}%' AND number LIKE '%${number}%' "
       + "AND location LIKE '%${location}%' AND deadline <= #{deadline}"

--- a/src/main/java/com/example/equipment/service/EquipmentService.java
+++ b/src/main/java/com/example/equipment/service/EquipmentService.java
@@ -1,12 +1,14 @@
 package com.example.equipment.service;
 
+import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
 import com.example.equipment.form.EquipmentForm;
 import java.util.List;
 
 public interface EquipmentService {
 
-  List<Equipment> findEquipment(String name, String number, String location);
+  List<FindEquipmentResponse> findEquipment(
+      String name, String number, String location, String deadline);
 
   Equipment findEquipmentById(int equipmentId);
 

--- a/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
@@ -1,10 +1,13 @@
 package com.example.equipment.service;
 
+import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
 import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.mapper.EquipmentMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
 import java.util.List;
 
 @Service
@@ -18,8 +21,13 @@ public class EquipmentServiceImpl implements EquipmentService {
 
   // 設備の条件検索
   @Override
-  public List<Equipment> findEquipment(String name, String number, String location) {
-    return equipmentMapper.findEquipment(name, number, location);
+  public List<FindEquipmentResponse> findEquipment(
+      String name, String number, String location, String deadline) {
+    if (StringUtils.hasLength(deadline)) {
+      return equipmentMapper.findEquipmentByDate(name, number, location, deadline);
+    } else {
+      return equipmentMapper.findEquipment(name, number, location);
+    }
   }
 
   // 設備のID検索

--- a/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
@@ -7,7 +7,6 @@ import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.mapper.EquipmentMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
-
 import java.util.List;
 
 @Service

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -180,10 +180,10 @@ public class EquipmentIntegrationTest {
 
     JSONAssert.assertEquals("""
         {
-        "equipmentId": 1,
-        "name": "真空ポンプA",
-        "number": "A1-C001A",
-        "location": "Area1"
+          "equipmentId": 1,
+          "name": "真空ポンプA",
+          "number": "A1-C001A",
+          "location": "Area1"
         }
         """, response, JSONCompareMode.STRICT);
   }

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -47,6 +47,7 @@ public class EquipmentIntegrationTest {
             "name": "真空ポンプA",
             "number": "A1-C001A",
             "location": "Area1",
+            "checkPlanId": 1,
             "checkType": "簡易点検",
             "deadline": "2023-09-30"
           },
@@ -55,6 +56,7 @@ public class EquipmentIntegrationTest {
             "name": "真空ポンプA",
             "number": "A1-C001A",
             "location": "Area1",
+            "checkPlanId": 2,
             "checkType": "本格点検",
             "deadline": "2026-09-30"
           },
@@ -63,6 +65,7 @@ public class EquipmentIntegrationTest {
             "name": "吸込ポンプB",
             "number": "A2-C002B",
             "location": "Area2",
+            "checkPlanId": 3,
             "checkType": "簡易点検",
             "deadline": "2023-10-30"
           },
@@ -71,6 +74,7 @@ public class EquipmentIntegrationTest {
             "name": "吸込ポンプB",
             "number": "A2-C002B",
             "location": "Area2",
+            "checkPlanId": 4,
             "checkType": "本格点検",
             "deadline": "2025-11-30"
           },
@@ -79,6 +83,7 @@ public class EquipmentIntegrationTest {
             "name": "吐出ポンプC",
             "number": "A3-C003C",
             "location": "Area3",
+            "checkPlanId": null,
             "checkType": null,
             "deadline": null
           }
@@ -104,6 +109,7 @@ public class EquipmentIntegrationTest {
             "name": "真空ポンプA",
             "number": "A1-C001A",
             "location": "Area1",
+            "checkPlanId": 1,
             "checkType": "簡易点検",
             "deadline": "2023-09-30"
           },
@@ -112,6 +118,7 @@ public class EquipmentIntegrationTest {
             "name": "真空ポンプA",
             "number": "A1-C001A",
             "location": "Area1",
+            "checkPlanId": 2,
             "checkType": "本格点検",
             "deadline": "2026-09-30"
           }
@@ -138,6 +145,7 @@ public class EquipmentIntegrationTest {
             "name": "真空ポンプA",
             "number": "A1-C001A",
             "location": "Area1",
+            "checkPlanId": 1,
             "checkType": "簡易点検",
             "deadline": "2023-09-30"
           }

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -29,11 +29,12 @@ public class EquipmentIntegrationTest {
   @Autowired
   MockMvc mockMvc;
 
-  // GETメソッドでname,number,locationのクエリパラメータを指定しない時に、設備が全数取得できステータスコード200が返されること
+  // GETメソッドでname,number,location,deadlineのクエリパラメータを指定しない時に、
+  // 設備と点検期限が全数取得できステータスコード200が返されること
   @Test
-  @DataSet(value = "datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
   @Transactional
-  void クエリパラメータを指定しない時に設備が全数取得できること() throws Exception {
+  void クエリパラメータを指定しない時に設備と点検期限が全数取得できること() throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.get("/equipments"))
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -41,34 +42,56 @@ public class EquipmentIntegrationTest {
 
     JSONAssert.assertEquals("""
         [
-        {
-        "equipmentId": 1,
-        "name": "真空ポンプA",
-        "number": "A1-C001A",
-        "location": "Area1"
-        },
-        {
-        "equipmentId": 2,
-        "name": "吸込ポンプB",
-        "number": "A2-C002B",
-        "location": "Area2"
-        },
-        {
-        "equipmentId": 3,
-        "name": "吐出ポンプC",
-        "number": "A3-C003C",
-        "location": "Area3"       
-        }
+          {
+            "equipmentId": 1,
+            "name": "真空ポンプA",
+            "number": "A1-C001A",
+            "location": "Area1",
+            "checkType": "簡易点検",
+            "deadline": "2023-09-30"
+          },
+          {
+            "equipmentId": 1,
+            "name": "真空ポンプA",
+            "number": "A1-C001A",
+            "location": "Area1",
+            "checkType": "本格点検",
+            "deadline": "2026-09-30"
+          },
+          {
+            "equipmentId": 2,
+            "name": "吸込ポンプB",
+            "number": "A2-C002B",
+            "location": "Area2",
+            "checkType": "簡易点検",
+            "deadline": "2023-10-30"
+          },
+          {
+            "equipmentId": 2,
+            "name": "吸込ポンプB",
+            "number": "A2-C002B",
+            "location": "Area2",
+            "checkType": "本格点検",
+            "deadline": "2025-11-30"
+          },
+          {
+            "equipmentId": 3,
+            "name": "吐出ポンプC",
+            "number": "A3-C003C",
+            "location": "Area3",
+            "checkType": null,
+            "deadline": null
+          }
         ]
         """, response, JSONCompareMode.STRICT);
   }
 
-  // GETメソッドでname,number,locationのクエリパラメータを指定した時に、
-  // 各内容に部分一致する設備が取得できステータスコード200が返されること
+  // GETメソッドでname,number,locationのクエリパラメータを指定しdeadlineを指定しない時に、
+  // 各内容に部分一致する設備と点検期限が取得できステータスコード200が返されること
   @Test
-  @DataSet(value = "datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
   @Transactional
-  void クエリパラメータに指定した内容と部分一致する設備が取得できること() throws Exception {
+  void name_number_locationに指定した内容と部分一致する設備と点検期限が取得できること() throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.get("/equipments?name=ポンプ&number=C00&location=1"))
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -76,19 +99,55 @@ public class EquipmentIntegrationTest {
 
     JSONAssert.assertEquals("""
         [
-        {
-        "equipmentId": 1,
-        "name": "真空ポンプA",
-        "number": "A1-C001A",
-        "location": "Area1"
-        }
+          {
+            "equipmentId": 1,
+            "name": "真空ポンプA",
+            "number": "A1-C001A",
+            "location": "Area1",
+            "checkType": "簡易点検",
+            "deadline": "2023-09-30"
+          },
+          {
+            "equipmentId": 1,
+            "name": "真空ポンプA",
+            "number": "A1-C001A",
+            "location": "Area1",
+            "checkType": "本格点検",
+            "deadline": "2026-09-30"
+          }
+        ]
+        """, response, JSONCompareMode.STRICT);
+  }
+
+  // GETメソッドでdeadlineのクエリパラメータを指定した時に、
+  // deadlineが指定した日付以前の設備と点検期限が取得できステータスコード200が返されること
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
+  @Transactional
+  void deadlineが指定した日付以前の設備と点検期限が取得できること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/equipments?name=ポンプ&number=C00&location=1&deadline=2023-10-30"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        [
+          {
+            "equipmentId": 1,
+            "name": "真空ポンプA",
+            "number": "A1-C001A",
+            "location": "Area1",
+            "checkType": "簡易点検",
+            "deadline": "2023-09-30"
+          }
         ]
         """, response, JSONCompareMode.STRICT);
   }
 
   // GETメソッドで設備が存在しない時に、空のListが返されステータスコード200が返されること
   @Test
-  @DataSet(value = "datasets/equipment/empty.yml")
+  @DataSet(value = "datasets/equipment/empty.yml, datasets/plan/plans.yml")
   @Transactional
   void 設備が存在しない時に空のListが取得できること() throws Exception {
     String response =

--- a/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
@@ -26,11 +26,11 @@ class EquipmentMapperTest {
   @Transactional
   void name_number_location_deadlineを指定しない時に全ての設備と点検期限を取得できること() {
     assertThat(equipmentMapper.findEquipment(null, null, null)).hasSize(5).contains(
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"),
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "本格点検", "2026-09-30"),
-        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", "簡易点検", "2023-10-30"),
-        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", "本格点検", "2025-11-30"),
-        new FindEquipmentResponse(3, "吐出ポンプC", "A3-C003C", "Area3", null, null)
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 1, "簡易点検", "2023-09-30"),
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 2, "本格点検", "2026-09-30"),
+        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", 3, "簡易点検", "2023-10-30"),
+        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", 4, "本格点検", "2025-11-30"),
+        new FindEquipmentResponse(3, "吐出ポンプC", "A3-C003C", "Area3", null, null, null)
     );
   }
 
@@ -41,8 +41,8 @@ class EquipmentMapperTest {
   void name_number_locationに指定した内容と部分一致する設備と点検期限が取得できること() {
     assertThat(equipmentMapper.findEquipment("ポンプ", "C00", "1"))
         .hasSize(2).contains(
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"),
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "本格点検", "2026-09-30")
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 1, "簡易点検", "2023-09-30"),
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 2, "本格点検", "2026-09-30")
     );
   }
 
@@ -52,7 +52,7 @@ class EquipmentMapperTest {
   void deadlineが指定した日付以前の設備と点検期限が取得できること() {
     assertThat(equipmentMapper.findEquipmentByDate("ポンプ", "C00", "1", "2023-10-30"))
         .hasSize(1).contains(
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30")
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 1, "簡易点検", "2023-09-30")
     );
   }
 

--- a/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
@@ -1,5 +1,6 @@
 package com.example.equipment.mapper;
 
+import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
@@ -19,29 +20,44 @@ class EquipmentMapperTest {
   @Autowired
   EquipmentMapper equipmentMapper;
 
-  // 設備検索でname,number,locationに文字列を指定しない場合、設備が全数返されることのテスト
+  // 設備検索でname,number,location,deadlineに文字列を指定しない場合、設備が全数返されることのテスト
   @Test
-  @DataSet(value = "datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
   @Transactional
-  void 全ての設備を取得できること() {
-    assertThat(equipmentMapper.findEquipment(null, null, null)).hasSize(3).contains(
-        new Equipment(1, "真空ポンプA", "A1-C001A", "Area1"),
-        new Equipment(2, "吸込ポンプB", "A2-C002B", "Area2"),
-        new Equipment(3, "吐出ポンプC", "A3-C003C", "Area3")
+  void name_number_location_deadlineを指定しない時に全ての設備と点検期限を取得できること() {
+    assertThat(equipmentMapper.findEquipment(null, null, null)).hasSize(5).contains(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"),
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "本格点検", "2026-09-30"),
+        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", "簡易点検", "2023-10-30"),
+        new FindEquipmentResponse(2, "吸込ポンプB", "A2-C002B", "Area2", "本格点検", "2025-11-30"),
+        new FindEquipmentResponse(3, "吐出ポンプC", "A3-C003C", "Area3", null, null)
+    );
+  }
+
+  // deadlineは指定しない場合
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
+  @Transactional
+  void name_number_locationに指定した内容と部分一致する設備と点検期限が取得できること() {
+    assertThat(equipmentMapper.findEquipment("ポンプ", "C00", "1"))
+        .hasSize(2).contains(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"),
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "本格点検", "2026-09-30")
     );
   }
 
   @Test
-  @DataSet(value = "datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
   @Transactional
-  void name_number_locationに指定した内容と部分一致する設備が取得できること() {
-    assertThat(equipmentMapper.findEquipment("ポンプ", "C00", "1")).hasSize(1).contains(
-        new Equipment(1, "真空ポンプA", "A1-C001A", "Area1")
+  void deadlineが指定した日付以前の設備と点検期限が取得できること() {
+    assertThat(equipmentMapper.findEquipmentByDate("ポンプ", "C00", "1", "2023-10-30"))
+        .hasSize(1).contains(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30")
     );
   }
 
   @Test
-  @DataSet(value = "datasets/equipment/empty.yml")
+  @DataSet(value = "datasets/equipment/empty.yml, datasets/plan/plans.yml")
   @Transactional
   void 設備が無い時に空のListが返されること() {
     assertThat(equipmentMapper.findEquipment(null, null, null)).isEmpty();

--- a/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
@@ -30,7 +30,7 @@ class EquipmentServiceTest {
   @Test
   public void 設備検索で点検期限の指定がある時にMapperのfindEquipmentByDateメソッドが呼び出されること() {
     List<FindEquipmentResponse> equipments = List.of(
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"));
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 1, "簡易点検", "2023-09-30"));
     doReturn(equipments).when(equipmentMapper).findEquipmentByDate("真空", "C001", "Area1", "2023-11-30");
 
     List<FindEquipmentResponse> actual =
@@ -43,7 +43,7 @@ class EquipmentServiceTest {
   @Test
   public void 設備検索で点検期限の指定がない時にMapperのfindEquipmentメソッドが呼び出されること() {
     List<FindEquipmentResponse> equipments = List.of(
-        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"));
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", 1, "簡易点検", "2023-09-30"));
     doReturn(equipments).when(equipmentMapper).findEquipment("真空", "C001", "Area1");
 
     List<FindEquipmentResponse> actual =

--- a/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.equipment.service;
 
+import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.mapper.EquipmentMapper;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +26,32 @@ class EquipmentServiceTest {
 
   @Mock
   EquipmentMapper equipmentMapper;
+
+  @Test
+  public void 設備検索で点検期限の指定がある時にMapperのfindEquipmentByDateメソッドが呼び出されること() {
+    List<FindEquipmentResponse> equipments = List.of(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"));
+    doReturn(equipments).when(equipmentMapper).findEquipmentByDate("真空", "C001", "Area1", "2023-11-30");
+
+    List<FindEquipmentResponse> actual =
+        equipmentServiceImpl.findEquipment("真空", "C001", "Area1", "2023-11-30");
+    assertThat(actual).isEqualTo(equipments);
+    verify(equipmentMapper, never()).findEquipment("真空", "C001", "Area1");
+    verify(equipmentMapper,times(1)).findEquipmentByDate("真空", "C001", "Area1", "2023-11-30");
+  }
+
+  @Test
+  public void 設備検索で点検期限の指定がない時にMapperのfindEquipmentメソッドが呼び出されること() {
+    List<FindEquipmentResponse> equipments = List.of(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", "簡易点検", "2023-09-30"));
+    doReturn(equipments).when(equipmentMapper).findEquipment("真空", "C001", "Area1");
+
+    List<FindEquipmentResponse> actual =
+        equipmentServiceImpl.findEquipment("真空", "C001", "Area1", null);
+    assertThat(actual).isEqualTo(equipments);
+    verify(equipmentMapper, never()).findEquipmentByDate("真空", "C001", "Area1", null);
+    verify(equipmentMapper,times(1)).findEquipment("真空", "C001", "Area1");
+  }
 
   @Test
   public void 設備のID検索で存在しないIDを指定した時に例外がスローされること() {


### PR DESCRIPTION
- GETメソッドでクエリパラメータに日付を入力すると、点検期限が指定した日付以前の設備と点検期限が取得できる機能を追加。
- 検索画面の条件入力欄に点検期限を追加。また検索結果に点検種別と点検期限欄を追加し、点検期限が１ヶ月以内の場合は赤く表示するよう設定。