### PR TITLE
不要な例外スローを削除

### DIFF
--- a/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/HistoryServiceImpl.java
@@ -19,17 +19,15 @@ public class HistoryServiceImpl implements HistoryService {
     this.equipmentMapper = equipmentMapper;
   }
 
-  // 指定した設備IDの点検履歴を取得するMapperを呼び出す。設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDの点検履歴を取得するMapperを呼び出す。
+  // 指定した設備IDの設備が存在しない場合であっても例外をスローせず取得できるようにする。
   @Override
    public List<History> findHistoryByEquipmentId(int equipmentId) {
-    equipmentMapper.findEquipmentById(equipmentId)
-        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
-
     return historyMapper.findHistoryByEquipmentId(equipmentId);
   }
 
   // formからgetしたリクエスト内容で、指定した設備IDの点検履歴を登録するMapperを呼び出す。
-  // 設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDの設備が存在しない場合は登録できないよう例外をスローする
   @Override
   public History createHistory(int equipmentId, HistoryForm form) {
     equipmentMapper.findEquipmentById(equipmentId)
@@ -59,11 +57,10 @@ public class HistoryServiceImpl implements HistoryService {
     historyMapper.deleteHistoryByCheckHistoryId(checkHistoryId);
   }
 
-  // 指定した設備IDに紐づく点検履歴を削除するMapperを呼びだす。設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDに紐づく点検履歴を削除するMapperを呼びだす。
+  // 指定した設備IDの設備が存在しない場合であっても例外はスローせず削除できるようにする。
   @Override
   public void deleteHistoryByEquipmentId(int equipmentId) {
-    equipmentMapper.findEquipmentById(equipmentId)
-        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
     historyMapper.deleteHistoryByEquipmentId(equipmentId);
   }
 }

--- a/src/main/java/com/example/equipment/service/PlanServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/PlanServiceImpl.java
@@ -19,16 +19,15 @@ public class PlanServiceImpl implements PlanService {
     this.equipmentMapper = equipmentMapper;
   }
 
-  // 指定した設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDに紐づく点検計画を取得する。
+  // 指定した設備IDの設備が存在しない場合であっても例外はスローせず取得できるようにする。
   @Override
   public List<Plan> findPlanByEquipmentId(int equipmentId) {
-    equipmentMapper.findEquipmentById(equipmentId)
-        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
-
     return planMapper.findPlanByEquipmentId(equipmentId);
   }
 
-  // 指定した設備IDが存在しない場合は例外をスローする
+  // 指定した設備IDの設備に紐づく点検計画を登録する。
+  // 指定した設備IDの設備が存在しない場合は登録できないよう例外をスローする。
   @Override
   public Plan createPlan(int equipmentId, PlanForm form) {
     equipmentMapper.findEquipmentById(equipmentId)
@@ -53,10 +52,10 @@ public class PlanServiceImpl implements PlanService {
     planMapper.deletePlanByCheckPlanId(checkPlanId);
   }
 
+  // 指定した設備IDに紐づく点検計画の削除。
+  // 指定した設備IDをもつ設備が存在しない場合であっても例外はスローせず削除できるようにする。
   @Override
   public void deletePlanByEquipmentId(int equipmentId) {
-    equipmentMapper.findEquipmentById(equipmentId)
-        .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
     planMapper.deletePlanByEquipmentId(equipmentId);
   }
 }

--- a/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
@@ -29,9 +29,9 @@ public class HistoryIntegrationTest {
   @Autowired
   MockMvc mockMvc;
 
-  // GETメソッドで存在する設備IDを指定した時に、指定した設備IDの点検履歴が取得できステータスコード200が返されること
+  // GETメソッドで設備IDを指定した時に、指定した設備IDの点検履歴が取得できステータスコード200が返されること
   @Test
-  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/history/histories.yml")
   @Transactional
   void 指定した設備IDの点検履歴が取得できること() throws Exception {
     String response =
@@ -59,31 +59,9 @@ public class HistoryIntegrationTest {
         """, response, JSONCompareMode.STRICT);
   }
 
-  // GETメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
-  @Test
-  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
-  @Transactional
-  void 指定したIDの設備が存在しない時に例外がスローされること() throws Exception {
-    String response =
-        mockMvc.perform(MockMvcRequestBuilders.get("/equipments/4/histories"))
-            .andExpect(MockMvcResultMatchers.status().isNotFound())
-            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-    JSONAssert.assertEquals("""
-        {
-          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
-          "status": "404",
-          "error": "Not Found",
-          "message": "Not Found",
-          "path": "/equipments/4/histories"
-        }
-        """, response, new CustomComparator(JSONCompareMode.STRICT,
-        new Customization("timestamp", ((o1, o2) -> true))));
-  }
-
   // GETメソッドで点検履歴が存在しない時に、空のListが返されステータスコード200が返されること
   @Test
-  @DataSet(value = "datasets/history/empty.yml, datasets/equipment/equipments.yml")
+  @DataSet(value = "datasets/history/empty.yml")
   @Transactional
   void 点検計画が存在しない時に空のListが取得できること() throws Exception {
     String response =
@@ -378,7 +356,7 @@ public class HistoryIntegrationTest {
         new Customization("timestamp", ((o1, o2) -> true))));
   }
 
-  // DELETEメソッドで存在する設備IDを指定した時に、点検履歴が削除できステータスコード200とメッセージが返されること
+  // DELETEメソッドで設備IDを指定した時に、点検履歴が削除できステータスコード200とメッセージが返されること
   @Test
   @DataSet(value = "datasets/history/histories.yml")
   @ExpectedDataSet(value = "datasets/history/delete_by_equipment_id.yml")
@@ -394,27 +372,5 @@ public class HistoryIntegrationTest {
           "message": "点検履歴が正常に削除されました"
         }
         """, response, JSONCompareMode.STRICT);
-  }
-
-  // DELETEメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
-  @Test
-  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
-  @Transactional
-  void 削除の際に指定した設備IDが存在しない時に例外がスローされること() throws Exception {
-    String response =
-        mockMvc.perform(MockMvcRequestBuilders.delete("/equipments/4/plans"))
-            .andExpect(MockMvcResultMatchers.status().isNotFound())
-            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-    JSONAssert.assertEquals("""
-        {
-          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
-          "status": "404",
-          "error": "Not Found",
-          "message": "Not Found",
-          "path": "/equipments/4/plans"
-        }
-        """, response, new CustomComparator(JSONCompareMode.STRICT,
-        new Customization("timestamp", ((o1, o2) -> true))));
   }
 }

--- a/src/test/java/com/example/equipment/integrationtest/PlanIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/PlanIntegrationTest.java
@@ -29,7 +29,7 @@ public class PlanIntegrationTest {
   @Autowired
   MockMvc mockMvc;
 
-  // GETメソッドで存在する設備IDを指定した時に、指定した設備IDの点検計画が取得できステータスコード200が返されること
+  // GETメソッドで設備IDを指定した時に、指定した設備IDの点検計画が取得できステータスコード200が返されること
   @Test
   @DataSet(value = "datasets/plan/plans.yml")
   @Transactional
@@ -57,28 +57,6 @@ public class PlanIntegrationTest {
                }
          ]
         """, response, JSONCompareMode.STRICT);
-  }
-
-  // GETメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
-  @Test
-  @DataSet(value = "datasets/plan/plans.yml, datasets/equipment/equipments.yml")
-  @Transactional
-  void 指定したIDの設備が存在しない時に例外がスローされること() throws Exception {
-    String response =
-        mockMvc.perform(MockMvcRequestBuilders.get("/equipments/4/plans"))
-            .andExpect(MockMvcResultMatchers.status().isNotFound())
-            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-    JSONAssert.assertEquals("""
-        {
-          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
-          "status": "404",
-          "error": "Not Found",
-          "message": "Not Found",
-          "path": "/equipments/4/plans"
-        }
-        """, response, new CustomComparator(JSONCompareMode.STRICT,
-        new Customization("timestamp", ((o1, o2) -> true))));
   }
 
   // GETメソッドで点検計画が存在しない時に、空のListが返されステータスコード200が返されること
@@ -375,7 +353,7 @@ public class PlanIntegrationTest {
         new Customization("timestamp", ((o1, o2) -> true))));
   }
 
-  // DELETEメソッドで存在する設備IDを指定した時に、点検計画が削除できステータスコード200とメッセージが返されること
+  // DELETEメソッドで設備IDを指定した時に、点検計画が削除できステータスコード200とメッセージが返されること
   @Test
   @DataSet(value = "datasets/plan/plans.yml")
   @ExpectedDataSet(value = "datasets/plan/delete_by_equipment_id.yml")
@@ -391,27 +369,5 @@ public class PlanIntegrationTest {
           "message": "点検計画が正常に削除されました"
         }
         """, response, JSONCompareMode.STRICT);
-  }
-
-  // DELETEメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
-  @Test
-  @DataSet(value = "datasets/plan/plans.yml, datasets/equipment/equipments.yml")
-  @Transactional
-  void 削除の際に指定した設備IDが存在しない時に例外がスローされること() throws Exception {
-    String response =
-        mockMvc.perform(MockMvcRequestBuilders.delete("/equipments/4/plans"))
-            .andExpect(MockMvcResultMatchers.status().isNotFound())
-            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-    JSONAssert.assertEquals("""
-        {
-          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
-          "status": "404",
-          "error": "Not Found",
-          "message": "Not Found",
-          "path": "/equipments/4/plans"
-        }
-        """, response, new CustomComparator(JSONCompareMode.STRICT,
-        new Customization("timestamp", ((o1, o2) -> true))));
   }
 }

--- a/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
+++ b/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
@@ -33,18 +33,6 @@ class HistoryServiceImplTest {
   EquipmentMapper equipmentMapper;
 
   @Test
-  public void 点検履歴取得の際に存在しない設備IDを指定した時に例外がスローされること() {
-    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
-
-    assertThatThrownBy(() -> historyServiceImpl.findHistoryByEquipmentId(99))
-        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
-          assertThat(e.getMessage()).isEqualTo("Not Found");
-        });
-    verify(equipmentMapper, times(1)).findEquipmentById(99);
-    verify(historyMapper, never()).findHistoryByEquipmentId(99);
-  }
-
-  @Test
   public void 点検履歴登録の際に存在しない設備IDを指定した時に例外がスローされること() {
     doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
 
@@ -80,17 +68,5 @@ class HistoryServiceImplTest {
         });
     verify(historyMapper, times(1)).findHistoryByCheckHistoryId(99);
     verify(historyMapper, never()).deleteHistoryByCheckHistoryId(99);
-  }
-
-  @Test
-  public void 点検履歴削除の際に存在しない設備IDを指定した時に例外がスローされること() {
-    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
-
-    assertThatThrownBy(() -> historyServiceImpl.deleteHistoryByEquipmentId(99))
-        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
-          assertThat(e.getMessage()).isEqualTo("Not Found");
-        });
-    verify(equipmentMapper, times(1)).findEquipmentById(99);
-    verify(historyMapper, never()).deleteHistoryByEquipmentId(99);
   }
 }

--- a/src/test/java/com/example/equipment/service/PlanServiceImplTest.java
+++ b/src/test/java/com/example/equipment/service/PlanServiceImplTest.java
@@ -35,18 +35,6 @@ class PlanServiceImplTest {
   EquipmentMapper equipmentMapper;
 
   @Test
-  public void 点検計画取得の際に存在しない設備IDを指定した時に例外がスローされること() {
-    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
-
-    assertThatThrownBy(() -> planserviceImpl.findPlanByEquipmentId(99))
-        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
-          assertThat(e.getMessage()).isEqualTo("Not Found");
-        });
-    verify(equipmentMapper, times(1)).findEquipmentById(99);
-    verify(planMapper, never()).findPlanByEquipmentId(99);
-  }
-
-  @Test
   public void 点検計画登録の際に存在しない設備IDを指定した時に例外がスローされること() {
     doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
 
@@ -82,17 +70,5 @@ class PlanServiceImplTest {
         });
     verify(planMapper, times(1)).findPlanByCheckPlanId(99);
     verify(planMapper, never()).deletePlanByCheckPlanId(99);
-  }
-
-  @Test
-  public void 点検計画削除の際に存在しない設備IDを指定した時に例外がスローされること() {
-    doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
-
-    assertThatThrownBy(() -> planserviceImpl.deletePlanByEquipmentId(99))
-        .isInstanceOfSatisfying(ResourceNotFoundException.class, e -> {
-          assertThat(e.getMessage()).isEqualTo("Not Found");
-        });
-    verify(equipmentMapper, times(1)).findEquipmentById(99);
-    verify(planMapper, never()).deletePlanByEquipmentId(99);
   }
 }


### PR DESCRIPTION
- 設備IDを指定して点検計画の検索・削除を行う際、指定した設備IDの設備が存在しない場合であっても例外をスローせず検索・削除を実施できるよう修正（指定した設備IDの設備が存在しなくてもそのIDに紐づく点検計画は存在する可能性があるため）
- 同様に点検履歴の検索・削除についても不要な例外スローを削除
- 例外スロー削除に伴いテストコードを修正