### PR TITLE
設備登録時に重複チェックを追加する

### DIFF
--- a/src/main/java/com/example/equipment/controller/EquipmentController.java
+++ b/src/main/java/com/example/equipment/controller/EquipmentController.java
@@ -1,6 +1,7 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.Equipment;
+import com.example.equipment.exception.DuplicateEquipmentException;
 import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.service.EquipmentService;
@@ -82,6 +83,18 @@ public class EquipmentController {
         "message", e.getMessage(),
         "path", request.getRequestURI());
     return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(value = DuplicateEquipmentException.class)
+  public ResponseEntity<Map<String, String>> handleDuplicateEquipment(
+      DuplicateEquipmentException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.CONFLICT.value()),
+        "error", HttpStatus.CONFLICT.getReasonPhrase(),
+        "message", e.getMessage(),
+        "path", request.getRequestURI());
+    return new ResponseEntity<>(body, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(value = MethodArgumentNotValidException.class)

--- a/src/main/java/com/example/equipment/exception/DuplicateEquipmentException.java
+++ b/src/main/java/com/example/equipment/exception/DuplicateEquipmentException.java
@@ -1,0 +1,7 @@
+package com.example.equipment.exception;
+
+public class DuplicateEquipmentException extends RuntimeException {
+  public DuplicateEquipmentException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -35,6 +35,10 @@ public interface EquipmentMapper {
   @Select("SELECT * FROM equipments WHERE equipment_id = #{equipmentId}")
   Optional<Equipment> findEquipmentById(int equipmentId);
 
+  @Select("SELECT EXISTS(SELECT 1 FROM equipments"
+      + " WHERE name = #{name} AND number = #{number} AND location = #{location})")
+  boolean existsDuplicateEquipment(String name, String number, String location);
+
   @Insert("INSERT INTO equipments (name, number, location)"
       + " VALUES (#{name}, #{number}, #{location})")
   @Options(useGeneratedKeys = true, keyProperty = "equipmentId")

--- a/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
+++ b/src/main/java/com/example/equipment/mapper/EquipmentMapper.java
@@ -39,6 +39,12 @@ public interface EquipmentMapper {
       + " WHERE name = #{name} AND number = #{number} AND location = #{location})")
   boolean existsDuplicateEquipment(String name, String number, String location);
 
+  @Select("SELECT EXISTS(SELECT 1 FROM equipments"
+      + " WHERE name = #{name} AND number = #{number} AND location = #{location}"
+      + " AND equipment_id != #{equipmentId})")
+  boolean existsDuplicateEquipmentWithOtherId(
+      int equipmentId, String name, String number, String location);
+
   @Insert("INSERT INTO equipments (name, number, location)"
       + " VALUES (#{name}, #{number}, #{location})")
   @Options(useGeneratedKeys = true, keyProperty = "equipmentId")

--- a/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.equipment.service;
 
 import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
+import com.example.equipment.exception.DuplicateEquipmentException;
 import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.mapper.EquipmentMapper;
@@ -39,6 +40,10 @@ public class EquipmentServiceImpl implements EquipmentService {
   // 設備の登録処理
   @Override
   public Equipment createEquipment(EquipmentForm form) {
+    if (equipmentMapper.existsDuplicateEquipment(
+        form.getName(), form.getNumber(), form.getLocation())) {
+      throw new DuplicateEquipmentException("同じ設備名称・設備番号・設置場所の設備が既に登録されています");
+    }
     Equipment equipment = new Equipment(form.getName(), form.getNumber(), form.getLocation());
     equipmentMapper.insertEquipment(equipment);
     return equipment;

--- a/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
+++ b/src/main/java/com/example/equipment/service/EquipmentServiceImpl.java
@@ -54,6 +54,9 @@ public class EquipmentServiceImpl implements EquipmentService {
   public void updateEquipment(int equipmentId, String name, String number, String location) {
     equipmentMapper.findEquipmentById(equipmentId)
         .orElseThrow(() -> new ResourceNotFoundException("Not Found"));
+    if (equipmentMapper.existsDuplicateEquipmentWithOtherId(equipmentId, name, number, location)) {
+      throw new DuplicateEquipmentException("同じ設備名称・設備番号・設置場所の設備が既に登録されています");
+    }
     equipmentMapper.updateEquipment(equipmentId, name, number, location);
   }
 

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -390,6 +390,37 @@ public class EquipmentIntegrationTest {
         """, response, JSONCompareMode.STRICT);
   }
 
+  // PATCHメソッドで他のequipmentIdと同じname,number,locationに更新しようとした時に、
+  // ステータスコード409とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 他のIDで重複する設備に更新しようとした時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/1")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "name": "吸込ポンプB",
+                  "number": "A2-C002B",
+                  "location": "Area2"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isConflict())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "409",
+          "error": "Conflict",
+          "message": "同じ設備名称・設備番号・設置場所の設備が既に登録されています",
+          "path": "/equipments/1"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
   // PATCHメソッドで存在しない設備IDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml")

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -333,6 +333,37 @@ public class EquipmentIntegrationTest {
         new Customization("timestamp", ((o1, o2) -> true))));
   }
 
+  // POSTメソッドで既に同じname,number,locationの設備が存在する時に、
+  // ステータスコード409とエラーメッセージが返されること
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 重複する設備を登録しようとした時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                {
+                  "name": "真空ポンプA",
+                  "number": "A1-C001A",
+                  "location": "Area1"
+                }
+                """))
+            .andExpect(MockMvcResultMatchers.status().isConflict())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "409",
+          "error": "Conflict",
+          "message": "同じ設備名称・設備番号・設置場所の設備が既に登録されています",
+          "path": "/equipments"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
   // PATCHメソッドで存在する設備IDを指定し正しくリクエストした時に、設備が更新できステータスコード200とメッセージが返されること
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml")

--- a/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
@@ -81,6 +81,34 @@ class EquipmentMapperTest {
 
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 重複する設備が存在する時にtrueが返されること() {
+    assertThat(equipmentMapper.existsDuplicateEquipment("真空ポンプA", "A1-C001A", "Area1")).isTrue();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 設備名称のみ異なる場合にfalseが返されること() {
+    assertThat(equipmentMapper.existsDuplicateEquipment("真空ポンプZ", "A1-C001A", "Area1")).isFalse();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 設備番号のみ異なる場合にfalseが返されること() {
+    assertThat(equipmentMapper.existsDuplicateEquipment("真空ポンプA", "A1-C001Z", "Area1")).isFalse();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 設置場所のみ異なる場合にfalseが返されること() {
+    assertThat(equipmentMapper.existsDuplicateEquipment("真空ポンプA", "A1-C001A", "AreaZ")).isFalse();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
   @ExpectedDataSet(value = "datasets/equipment/insert_equipment.yml", ignoreCols = "equipment_id")
   @Transactional
   void 設備登録ができ既存のIDより大きい数字のIDが採番されること() {

--- a/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/EquipmentMapperTest.java
@@ -109,6 +109,22 @@ class EquipmentMapperTest {
 
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 他のIDで重複する設備が存在する時にtrueが返されること() {
+    assertThat(equipmentMapper
+        .existsDuplicateEquipmentWithOtherId(2, "真空ポンプA", "A1-C001A", "Area1")).isTrue();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
+  @Transactional
+  void 同じIDで重複する設備の場合にfalseが返されること() {
+    assertThat(equipmentMapper
+        .existsDuplicateEquipmentWithOtherId(1, "真空ポンプA", "A1-C001A", "Area1")).isFalse();
+  }
+
+  @Test
+  @DataSet(value = "datasets/equipment/equipments.yml")
   @ExpectedDataSet(value = "datasets/equipment/insert_equipment.yml", ignoreCols = "equipment_id")
   @Transactional
   void 設備登録ができ既存のIDより大きい数字のIDが採番されること() {

--- a/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
@@ -105,6 +105,20 @@ class EquipmentServiceTest {
   }
 
   @Test
+  public void 他のIDで重複する設備に更新しようとした時に例外がスローされること() {
+    doReturn(Optional.of(new Equipment(1, "真空ポンプA", "A1-C001A", "Area1")))
+        .when(equipmentMapper).findEquipmentById(1);
+    doReturn(true).when(equipmentMapper)
+        .existsDuplicateEquipmentWithOtherId(1, "吸込ポンプB", "A2-C002B", "Area2");
+
+    assertThatThrownBy(() -> equipmentServiceImpl.updateEquipment(1, "吸込ポンプB", "A2-C002B", "Area2"))
+        .isInstanceOfSatisfying(DuplicateEquipmentException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("同じ設備名称・設備番号・設置場所の設備が既に登録されています");
+        });
+    verify(equipmentMapper, never()).updateEquipment(1, "吸込ポンプB", "A2-C002B", "Area2");
+  }
+
+  @Test
   public void 設備削除で存在しないIDを指定した時に例外がスローされること() {
     doReturn(Optional.empty()).when(equipmentMapper).findEquipmentById(99);
 

--- a/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/example/equipment/service/EquipmentServiceTest.java
@@ -2,6 +2,7 @@ package com.example.equipment.service;
 
 import com.example.equipment.controller.FindEquipmentResponse;
 import com.example.equipment.entity.Equipment;
+import com.example.equipment.exception.DuplicateEquipmentException;
 import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.mapper.EquipmentMapper;
@@ -72,10 +73,23 @@ class EquipmentServiceTest {
   public void formからgetした内容で設備が登録できること() {
     EquipmentForm form = new EquipmentForm("ポンプA", "C001A", "Area1");
     Equipment expectedEquipment = new Equipment("ポンプA", "C001A", "Area1");
+    doReturn(false).when(equipmentMapper).existsDuplicateEquipment("ポンプA", "C001A", "Area1");
     doNothing().when(equipmentMapper).insertEquipment(expectedEquipment);
 
     assertThat(equipmentServiceImpl.createEquipment(form)).isEqualTo(expectedEquipment);
     verify(equipmentMapper, times(1)).insertEquipment(expectedEquipment);
+  }
+
+  @Test
+  public void 重複する設備を登録しようとした時に例外がスローされること() {
+    EquipmentForm form = new EquipmentForm("ポンプA", "C001A", "Area1");
+    doReturn(true).when(equipmentMapper).existsDuplicateEquipment("ポンプA", "C001A", "Area1");
+
+    assertThatThrownBy(() -> equipmentServiceImpl.createEquipment(form))
+        .isInstanceOfSatisfying(DuplicateEquipmentException.class, e -> {
+          assertThat(e.getMessage()).isEqualTo("同じ設備名称・設備番号・設置場所の設備が既に登録されています");
+        });
+    verify(equipmentMapper, never()).insertEquipment(new Equipment("ポンプA", "C001A", "Area1"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 設備名称・設備番号・設置場所が全て同じ設備は登録できないようにした
- 設備更新時も、他のequipmentIdで同じ設備名称・設備番号・設置場所の設備が存在する場合は更新できないようにした
- 重複時は `DuplicateEquipmentException` をスローし、409 Conflict を返す
- `existsDuplicateEquipment` に `SELECT EXISTS` を使用した効率的な重複チェッククエリを追加

## Test plan
- [ ] `EquipmentServiceTest`: 重複時に例外がスローされること / 重複なし時に登録できること（登録・更新それぞれ）
- [ ] `EquipmentMapperTest`: trueが返るケース / 名称・番号・場所それぞれのみ異なる場合にfalseが返ること / 他IDで重複時にtrue・同IDで重複時にfalseが返ること
- [ ] `EquipmentIntegrationTest`: 重複登録・重複更新時に409とエラーメッセージが返されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)