### PR TITLE
テストケースを追加する

### DIFF
--- a/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
@@ -255,6 +255,36 @@ public class HistoryIntegrationTest {
         new Customization("timestamp", ((o1, o2) -> true))));
   }
 
+  // POSTメソッドでresultが50文字を超える時に、ステータスコード400とエラーメッセージが返されること（@Sizeのバリデーション確認）
+  @Test
+  @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
+  @Transactional
+  void 登録時のリクエストでresultが50文字を超える時にエラーメッセージが返されること() throws Exception {
+    String response =
+        mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                    {
+                      "implementationDate": "2015-09-30",
+                      "checkTypeId": 3,
+                      "result": "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあ"
+                    }
+                    """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+        {
+          "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
+          "status": "400",
+          "error": "Bad Request",
+          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "path": "/equipments/1/histories"
+        }
+        """, response, new CustomComparator(JSONCompareMode.STRICT,
+        new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
   // PATCHメソッドで存在する点検履歴IDを指定し正しくリクエスト（implementationDate,checkTypeId,resultが
   // 全て入力されており、checkTypeIdは1以上の値を入力、resultは50文字以内で入力）した時に、
   // 点検履歴が更新できステータスコード200とメッセージが返されること

--- a/src/test/java/com/example/equipment/mapper/HistoryMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/HistoryMapperTest.java
@@ -40,6 +40,14 @@ class HistoryMapperTest {
   @Test
   @DataSet(value = "datasets/history/histories.yml")
   @Transactional
+  void 指定した点検履歴IDが存在する時に対応するHistoryが返されること() {
+    assertThat(historyMapper.findHistoryByCheckHistoryId(1))
+        .contains(new History(1, 1, 1, "2022-09-30", "良"));
+  }
+
+  @Test
+  @DataSet(value = "datasets/history/histories.yml")
+  @Transactional
   void 指定した点検履歴IDが存在しない時に空のOptionalが返されること() {
     assertThat(historyMapper.findHistoryByCheckHistoryId(5)).isEmpty();
   }

--- a/src/test/java/com/example/equipment/mapper/MailMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/MailMapperTest.java
@@ -1,0 +1,40 @@
+package com.example.equipment.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.equipment.controller.FindEquipmentResponse;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MailMapperTest {
+
+  @Autowired
+  MailMapper mailMapper;
+
+  @Test
+  @DataSet(value = "datasets/check_type/check_types.yml, datasets/equipment/equipments.yml,"
+      + " datasets/mail/plans_mixed_deadline.yml")
+  @Transactional
+  void deadlineが存在する設備の点検計画のみ取得できること() {
+    assertThat(mailMapper.findEquipmentWithDeadline()).hasSize(1).contains(
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", true, 1, "簡易点検",
+            "2023-09-30")
+    );
+  }
+
+  @Test
+  @DataSet(value = "datasets/check_type/check_types.yml, datasets/equipment/equipments.yml,"
+      + " datasets/plan/empty.yml")
+  @Transactional
+  void deadlineが存在しない時に空のListが返されること() {
+    assertThat(mailMapper.findEquipmentWithDeadline()).isEmpty();
+  }
+}

--- a/src/test/java/com/example/equipment/mapper/PlanMapperTest.java
+++ b/src/test/java/com/example/equipment/mapper/PlanMapperTest.java
@@ -40,6 +40,14 @@ class PlanMapperTest {
   @Test
   @DataSet(value = "datasets/plan/plans.yml")
   @Transactional
+  void 指定した点検計画IDが存在する時に対応するPlanが返されること() {
+    assertThat(planMapper.findPlanByCheckPlanId(1))
+        .contains(new Plan(1, 1, 1, 1, "year", "2023-09-30", false));
+  }
+
+  @Test
+  @DataSet(value = "datasets/plan/plans.yml")
+  @Transactional
   void 指定した点検計画IDが存在しない時に空のOptionalが返されること() {
     assertThat(planMapper.findPlanByCheckPlanId(5)).isEmpty();
   }

--- a/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
+++ b/src/test/java/com/example/equipment/service/HistoryServiceImplTest.java
@@ -1,19 +1,5 @@
 package com.example.equipment.service;
 
-import com.example.equipment.entity.Equipment;
-import com.example.equipment.entity.History;
-import com.example.equipment.exception.ResourceNotFoundException;
-import com.example.equipment.form.HistoryForm;
-import com.example.equipment.mapper.EquipmentMapper;
-import com.example.equipment.mapper.HistoryMapper;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
@@ -21,6 +7,19 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import com.example.equipment.entity.Equipment;
+import com.example.equipment.entity.History;
+import com.example.equipment.exception.ResourceNotFoundException;
+import com.example.equipment.form.HistoryForm;
+import com.example.equipment.mapper.EquipmentMapper;
+import com.example.equipment.mapper.HistoryMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 // Mapperを呼び出しているだけの部分については、単体テストを割愛しMapper単体テスト及び結合テストで確認する。
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +75,7 @@ class HistoryServiceImplTest {
   }
 
   @Test
-  public void 点検履歴削除の際に存在しない点検計画IDを指定した時に例外がスローされること() {
+  public void 点検履歴削除の際に存在しない点検履歴IDを指定した時に例外がスローされること() {
     doReturn(Optional.empty()).when(historyMapper).findHistoryByCheckHistoryId(99);
 
     assertThatThrownBy(() -> historyServiceImpl.deleteHistoryByCheckHistoryId(99))

--- a/src/test/java/com/example/equipment/service/MailServiceImplTest.java
+++ b/src/test/java/com/example/equipment/service/MailServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.example.equipment.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.equipment.controller.FindEquipmentResponse;
+import com.example.equipment.mapper.MailMapper;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceImplTest {
+
+  @InjectMocks
+  MailServiceImpl mailServiceImpl;
+
+  @Mock
+  MailMapper mailMapper;
+
+  @Mock
+  MailSender mailSender;
+
+  @Test
+  void deadlineが1ヶ月後の場合にメールが送信されること() {
+    String deadline = LocalDate.now().plusMonths(1).toString();
+    FindEquipmentResponse equipment =
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", true, 1, "簡易点検", deadline);
+    doReturn(List.of(equipment)).when(mailMapper).findEquipmentWithDeadline();
+
+    mailServiceImpl.mailSend();
+
+    verify(mailSender).send(any(SimpleMailMessage.class));
+  }
+
+  @Test
+  void deadlineが1ヶ月後でない場合にメールが送信されないこと() {
+    String deadline = LocalDate.now().plusMonths(2).toString();
+    FindEquipmentResponse equipment =
+        new FindEquipmentResponse(1, "真空ポンプA", "A1-C001A", "Area1", true, 1, "簡易点検", deadline);
+    doReturn(List.of(equipment)).when(mailMapper).findEquipmentWithDeadline();
+
+    mailServiceImpl.mailSend();
+
+    verify(mailSender, never()).send(any(SimpleMailMessage.class));
+  }
+}

--- a/src/test/resources/datasets/mail/plans_mixed_deadline.yml
+++ b/src/test/resources/datasets/mail/plans_mixed_deadline.yml
@@ -1,0 +1,14 @@
+plans:
+  - check_plan_id: 1
+    equipment_id: 1
+    check_type_id: 1
+    period_value: 1
+    period_unit: "year"
+    deadline: "2023-09-30"
+    is_manual_override: 0
+  - check_plan_id: 2
+    equipment_id: 2
+    check_type_id: 2
+    period_value: 1
+    period_unit: "year"
+    is_manual_override: 0


### PR DESCRIPTION
## Summary
- HistoryMapperTest・PlanMapperTestにfindBy~Idの正常系テストを追加
- MailMapperTest・MailServiceImplTestを新規追加
- HistoryIntegrationTestに登録時のresultバリデーションテストを追加
- HistoryServiceImplTestのテストメソッド名の誤記を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)