### PR TITLE
例外ハンドラーを@RestControllerAdviceで共通化する

### DIFF
--- a/src/main/java/com/example/equipment/controller/CheckTypeController.java
+++ b/src/main/java/com/example/equipment/controller/CheckTypeController.java
@@ -1,20 +1,14 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.CheckType;
-import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.CheckTypeForm;
 import com.example.equipment.service.CheckTypeService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,29 +43,5 @@ public class CheckTypeController {
       @PathVariable("checkTypeId") int checkTypeId) {
     checkTypeService.deleteCheckType(checkTypeId);
     return ResponseEntity.ok(Map.of("message", "点検種別が正常に削除されました"));
-  }
-
-  @ExceptionHandler(value = ResourceNotFoundException.class)
-  public ResponseEntity<Map<String, String>> handleNoResourceFound(
-      ResourceNotFoundException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        "message", "nameは必須項目です。20文字以内で入力してください",
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/com/example/equipment/controller/EquipmentCheckTypeInclusionController.java
+++ b/src/main/java/com/example/equipment/controller/EquipmentCheckTypeInclusionController.java
@@ -1,20 +1,14 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.EquipmentCheckTypeInclusion;
-import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentCheckTypeInclusionForm;
 import com.example.equipment.service.EquipmentCheckTypeInclusionService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,29 +67,5 @@ public class EquipmentCheckTypeInclusionController {
       @PathVariable("equipmentId") int equipmentId) {
     inclusionService.deleteInclusionsByEquipmentId(equipmentId);
     return ResponseEntity.ok(Map.of("message", "包含関係が正常に削除されました"));
-  }
-
-  @ExceptionHandler(value = ResourceNotFoundException.class)
-  public ResponseEntity<Map<String, String>> handleNoResourceFound(
-      ResourceNotFoundException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        "message", "upperCheckTypeId,lowerCheckTypeIdは1以上の値を入力してください",
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/com/example/equipment/controller/EquipmentController.java
+++ b/src/main/java/com/example/equipment/controller/EquipmentController.java
@@ -1,21 +1,14 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.Equipment;
-import com.example.equipment.exception.DuplicateEquipmentException;
-import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.EquipmentForm;
 import com.example.equipment.service.EquipmentService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -72,41 +65,5 @@ public class EquipmentController {
       @PathVariable("equipmentId") int equipmentId) {
     equipmentService.deleteEquipment(equipmentId);
     return ResponseEntity.ok(Map.of("message", "設備が正常に削除されました"));
-  }
-
-  @ExceptionHandler(value = ResourceNotFoundException.class)
-  public ResponseEntity<Map<String, String>> handleNoResourceFound(
-      ResourceNotFoundException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(value = DuplicateEquipmentException.class)
-  public ResponseEntity<Map<String, String>> handleDuplicateEquipment(
-      DuplicateEquipmentException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.CONFLICT.value()),
-        "error", HttpStatus.CONFLICT.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        "message", "name,number,locationは必須項目です。20文字以内で入力してください",
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/com/example/equipment/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/equipment/controller/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.example.equipment.controller;
+
+import com.example.equipment.exception.DuplicateEquipmentException;
+import com.example.equipment.exception.ResourceNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<Map<String, String>> handleNoResourceFound(
+      ResourceNotFoundException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+        "message", e.getMessage(),
+        "path", request.getRequestURI());
+    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(DuplicateEquipmentException.class)
+  public ResponseEntity<Map<String, String>> handleDuplicateEquipment(
+      DuplicateEquipmentException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.CONFLICT.value()),
+        "error", HttpStatus.CONFLICT.getReasonPhrase(),
+        "message", e.getMessage(),
+        "path", request.getRequestURI());
+    return new ResponseEntity<>(body, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e, HttpServletRequest request) {
+    String message = e.getBindingResult().getFieldErrors().stream()
+        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+        .sorted()
+        .collect(Collectors.joining(", "));
+    Map<String, String> body = Map.of(
+        "timestamp", ZonedDateTime.now().toString(),
+        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+        "message", message,
+        "path", request.getRequestURI());
+    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/example/equipment/controller/HistoryController.java
+++ b/src/main/java/com/example/equipment/controller/HistoryController.java
@@ -1,20 +1,14 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.History;
-import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.HistoryForm;
 import com.example.equipment.service.HistoryService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,32 +68,5 @@ public class HistoryController {
       @PathVariable("equipmentId") int equipmentId) {
     historyService.deleteHistoryByEquipmentId(equipmentId);
     return ResponseEntity.ok(Map.of("message", "点検履歴が正常に削除されました"));
-  }
-
-  // リソースが存在しない時のエラーハンドリング
-  @ExceptionHandler(value = ResourceNotFoundException.class)
-  public ResponseEntity<Map<String, String>> handleNoResourceFound(
-      ResourceNotFoundException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-  }
-
-  // バリデーションチェックによるエラーハンドリング
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        "message",
-        "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/com/example/equipment/controller/PlanController.java
+++ b/src/main/java/com/example/equipment/controller/PlanController.java
@@ -1,20 +1,14 @@
 package com.example.equipment.controller;
 
 import com.example.equipment.entity.Plan;
-import com.example.equipment.exception.ResourceNotFoundException;
 import com.example.equipment.form.PlanForm;
 import com.example.equipment.service.PlanService;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,29 +61,5 @@ public class PlanController {
       @PathVariable("equipmentId") int equipmentId) {
     planService.deletePlanByEquipmentId(equipmentId);
     return ResponseEntity.ok(Map.of("message", "点検計画が正常に削除されました"));
-  }
-
-  @ExceptionHandler(value = ResourceNotFoundException.class)
-  public ResponseEntity<Map<String, String>> handleNoResourceFound(
-      ResourceNotFoundException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-        "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-        "message", e.getMessage(),
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e, HttpServletRequest request) {
-    Map<String, String> body = Map.of(
-        "timestamp", ZonedDateTime.now().toString(),
-        "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-        "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        "message", "checkTypeId,periodValue,periodUnitは必須項目です",
-        "path", request.getRequestURI());
-    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/test/java/com/example/equipment/integrationtest/CheckTypeIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/CheckTypeIntegrationTest.java
@@ -96,7 +96,7 @@ public class CheckTypeIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "nameは必須項目です。20文字以内で入力してください",
+          "message": "name: 必須項目です",
           "path": "/check-types"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -121,7 +121,7 @@ public class CheckTypeIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "nameは必須項目です。20文字以内で入力してください",
+          "message": "name: 必須項目です",
           "path": "/check-types"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -146,7 +146,7 @@ public class CheckTypeIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "nameは必須項目です。20文字以内で入力してください",
+          "message": "name: 20文字以内で入力してください",
           "path": "/check-types"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentCheckTypeInclusionIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentCheckTypeInclusionIntegrationTest.java
@@ -111,7 +111,7 @@ public class EquipmentCheckTypeInclusionIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "upperCheckTypeId,lowerCheckTypeIdは1以上の値を入力してください",
+          "message": "upperCheckTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/inclusions"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -137,7 +137,7 @@ public class EquipmentCheckTypeInclusionIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "upperCheckTypeId,lowerCheckTypeIdは1以上の値を入力してください",
+          "message": "lowerCheckTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/inclusions"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -168,7 +168,8 @@ public class EquipmentCheckTypeInclusionIntegrationTest {
   @DataSet(value = "datasets/check_type/check_types.yml, datasets/equipment/equipments.yml,"
       + " datasets/inclusion/inclusions.yml")
   @Transactional
-  void 包含関係更新の際に存在しない包含関係IDを指定した時に404エラーが返されること() throws Exception {
+  void 包含関係更新の際に存在しない包含関係IDを指定した時に404エラーが返されること()
+      throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/1/inclusions/99")
             .contentType(MediaType.APPLICATION_JSON)
             .content("""
@@ -196,7 +197,7 @@ public class EquipmentCheckTypeInclusionIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "upperCheckTypeId,lowerCheckTypeIdは1以上の値を入力してください",
+          "message": "upperCheckTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/inclusions/1"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -223,7 +224,8 @@ public class EquipmentCheckTypeInclusionIntegrationTest {
   @DataSet(value = "datasets/check_type/check_types.yml, datasets/equipment/equipments.yml,"
       + " datasets/inclusion/inclusions.yml")
   @Transactional
-  void 包含関係削除の際に存在しない包含関係IDを指定した時に404エラーが返されること() throws Exception {
+  void 包含関係削除の際に存在しない包含関係IDを指定した時に404エラーが返されること()
+      throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.delete("/equipments/1/inclusions/99"))
         .andExpect(MockMvcResultMatchers.status().isNotFound());
   }

--- a/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/EquipmentIntegrationTest.java
@@ -99,7 +99,8 @@ public class EquipmentIntegrationTest {
   @DataSet(value = "datasets/check_type/check_types.yml, datasets/equipment/equipments.yml,"
       + " datasets/plan/plans.yml")
   @Transactional
-  void name_number_locationに指定した内容と部分一致する設備と点検期限が取得できること() throws Exception {
+  void name_number_locationに指定した内容と部分一致する設備と点検期限が取得できること()
+      throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.get("/equipments?name=ポンプ&number=C00&location=1"))
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -220,14 +221,14 @@ public class EquipmentIntegrationTest {
   void 設備が登録できること() throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content("""
-                {
-                  "name": "真空ポンプB",
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("""
+                    {
+                      "name": "真空ポンプB",
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isCreated())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -248,12 +249,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": null,
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": null,
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -262,7 +263,7 @@ public class EquipmentIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "name,number,locationは必須項目です。20文字以内で入力してください",
+          "message": "name: 必須項目です",
           "path": "/equipments"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -277,12 +278,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "",
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": "",
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -291,7 +292,7 @@ public class EquipmentIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "name,number,locationは必須項目です。20文字以内で入力してください",
+          "message": "name: 必須項目です",
           "path": "/equipments"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -301,17 +302,18 @@ public class EquipmentIntegrationTest {
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml")
   @Transactional
-  void 登録時のリクエストで20文字を超えている項目がある時にエラーメッセージが返されること() throws Exception {
+  void 登録時のリクエストで20文字を超えている項目がある時にエラーメッセージが返されること()
+      throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "aaaaaaaaaaaaaaaaaaaaa",
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": "aaaaaaaaaaaaaaaaaaaaa",
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -320,7 +322,7 @@ public class EquipmentIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "name,number,locationは必須項目です。20文字以内で入力してください",
+          "message": "name: 20文字以内で入力してください",
           "path": "/equipments"
           }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -335,12 +337,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "真空ポンプA",
-                  "number": "A1-C001A",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": "真空ポンプA",
+                      "number": "A1-C001A",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isConflict())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -365,12 +367,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/1")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "真空ポンプB",
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": "真空ポンプB",
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -389,12 +391,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/1")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "吸込ポンプB",
-                  "number": "A2-C002B",
-                  "location": "Area2"
-                }
-                """))
+                    {
+                      "name": "吸込ポンプB",
+                      "number": "A2-C002B",
+                      "location": "Area2"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isConflict())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -418,12 +420,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/4")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": "真空ポンプB",
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": "真空ポンプB",
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isNotFound())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -447,12 +449,12 @@ public class EquipmentIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.patch("/equipments/1")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
-                {
-                  "name": null,
-                  "number": "A1-C001B",
-                  "location": "Area1"
-                }
-                """))
+                    {
+                      "name": null,
+                      "number": "A1-C001B",
+                      "location": "Area1"
+                    }
+                    """))
             .andExpect(MockMvcResultMatchers.status().isBadRequest())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -461,7 +463,7 @@ public class EquipmentIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "name,number,locationは必須項目です。20文字以内で入力してください",
+          "message": "name: 必須項目です",
           "path": "/equipments/1"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,

--- a/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/HistoryIntegrationTest.java
@@ -157,7 +157,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "implementationDate: 必須項目です",
           "path": "/equipments/1/histories"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -188,7 +188,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "implementationDate: 必須項目です",
           "path": "/equipments/1/histories"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -219,7 +219,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "checkTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/histories"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -229,7 +229,8 @@ public class HistoryIntegrationTest {
   @Test
   @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
   @Transactional
-  void 登録時のリクエストでcheckTypeIdがnullの時にエラーメッセージが返されること() throws Exception {
+  void 登録時のリクエストでcheckTypeIdがnullの時にエラーメッセージが返されること()
+      throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -248,7 +249,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "checkTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/histories"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -259,7 +260,8 @@ public class HistoryIntegrationTest {
   @Test
   @DataSet(value = "datasets/history/histories.yml, datasets/equipment/equipments.yml")
   @Transactional
-  void 登録時のリクエストでresultが50文字を超える時にエラーメッセージが返されること() throws Exception {
+  void 登録時のリクエストでresultが50文字を超える時にエラーメッセージが返されること()
+      throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/histories")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -278,7 +280,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "result: 50文字以内で入力してください",
           "path": "/equipments/1/histories"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -368,7 +370,7 @@ public class HistoryIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "implementationDate,checkTypeId,resultは必須項目です。resultは50文字以内で入力してください",
+          "message": "implementationDate: 必須項目です",
           "path": "/histories/2"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,

--- a/src/test/java/com/example/equipment/integrationtest/PlanIntegrationTest.java
+++ b/src/test/java/com/example/equipment/integrationtest/PlanIntegrationTest.java
@@ -155,7 +155,7 @@ public class PlanIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "checkTypeId,periodValue,periodUnitは必須項目です",
+          "message": "checkTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/plans"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -186,7 +186,7 @@ public class PlanIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "checkTypeId,periodValue,periodUnitは必須項目です",
+          "message": "periodUnit: day,week,month,yearのいずれかを入力してください, periodUnit: 必須項目です",
           "path": "/equipments/1/plans"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -217,7 +217,7 @@ public class PlanIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "checkTypeId,periodValue,periodUnitは必須項目です",
+          "message": "periodUnit: day,week,month,yearのいずれかを入力してください",
           "path": "/equipments/1/plans"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -227,7 +227,8 @@ public class PlanIntegrationTest {
   @Test
   @DataSet(value = "datasets/equipment/equipments.yml, datasets/plan/plans.yml")
   @Transactional
-  void 登録時のリクエストでcheckTypeIdがnullの時にエラーメッセージが返されること() throws Exception {
+  void 登録時のリクエストでcheckTypeIdがnullの時にエラーメッセージが返されること()
+      throws Exception {
     String response =
         mockMvc.perform(MockMvcRequestBuilders.post("/equipments/1/plans")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -247,7 +248,7 @@ public class PlanIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "checkTypeId,periodValue,periodUnitは必須項目です",
+          "message": "checkTypeId: 1以上の値を入力してください",
           "path": "/equipments/1/plans"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,
@@ -333,7 +334,7 @@ public class PlanIntegrationTest {
           "timestamp": "2023-07-14T12:00:00.511021+09:00[Asia/Tokyo]",
           "status": "400",
           "error": "Bad Request",
-          "message": "checkTypeId,periodValue,periodUnitは必須項目です",
+          "message": "periodUnit: 必須項目です",
           "path": "/plans/2"
         }
         """, response, new CustomComparator(JSONCompareMode.STRICT,


### PR DESCRIPTION
## Summary

- 各コントローラーに重複していた `@ExceptionHandler` メソッドを廃止し、`GlobalExceptionHandler`（`@RestControllerAdvice`）に集約した
- `ResourceNotFoundException`（404）・`DuplicateEquipmentException`（409）・`MethodArgumentNotValidException`（400）の3種類を共通ハンドリング
- `MethodArgumentNotValidException` のエラーメッセージはフォームのバリデーションアノテーションから動的に生成するよう変更（例: `"name: 必須項目です"`）
- 統合テストの期待値を新しいメッセージ形式に合わせて更新